### PR TITLE
Fix repo issues: CLAUDE.md, unit tests, TLS policy, third-party licenses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,14 +5,14 @@ Substance Painter plugin bridging Adobe Substance 3D Painter with NVIDIA RTX Rem
 ## Module Map (post-v0.5.0)
 
 | File | Purpose |
-|------|---------|
+|------|-------|
 | `__init__.py` | Plugin registration entry; loads `core.py` via `_load_core_module()` |
 | `core.py` | Central orchestration (~45 KB); `RemixConnectorPlugin` class |
 | `remix_api.py` | REST client for RTX Remix Toolkit (~26 KB); `RemixAPIClient` class |
 | `texture_processor.py` | DDS pipeline + texconv/Blender invocation (~11 KB) |
 | `painter_controller.py` | Substance Painter API wrapper |
 | `async_utils.py` | Qt worker thread + signal plumbing |
-| `dependency_manager.py` | Runtime dependency loading |
+| `dependency_manager.py` | Runtime dependency loading from `_vendor/` |
 | `diagnostics_dialog.py` | In-Painter diagnostics panel |
 | `settings_dialog.py` | Tabbed settings UI |
 | `settings_schema.py` | Settings key definitions and defaults |
@@ -30,8 +30,8 @@ Substance Painter plugin bridging Adobe Substance 3D Painter with NVIDIA RTX Rem
 ## Network / TLS Policy
 
 All HTTP calls go through `RemixAPIClient.make_request()`. TLS verification:
-- **Disabled** (`verify=False`) for `localhost` / `127.0.0.1` / `[::1]` — Remix runs locally over HTTP
-- **Enabled** (`verify=True`) for any non-loopback host
+- **Disabled** (`verify=False`) when the URL contains `localhost`, `127.0.0.1`, or `[::1]` (substring match — note: a URL like `https://localhost.evil.com` also matches; tighten host parsing if this client is ever exposed to untrusted input)
+- **Enabled** (`verify=True`) for all other hosts
 
 Do NOT add direct `requests.get/post` calls outside `make_request()`. All new endpoints
 must use the method to preserve retry logic and TLS policy.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,59 @@
+# Substance2Remix — LLM Assistant Bootstrap
+
+Substance Painter plugin bridging Adobe Substance 3D Painter with NVIDIA RTX Remix.
+
+## Module Map (post-v0.5.0)
+
+| File | Purpose |
+|------|---------|
+| `__init__.py` | Plugin registration entry; loads `core.py` via `_load_core_module()` |
+| `core.py` | Central orchestration (~45 KB); `RemixConnectorPlugin` class |
+| `remix_api.py` | REST client for RTX Remix Toolkit (~26 KB); `RemixAPIClient` class |
+| `texture_processor.py` | DDS pipeline + texconv/Blender invocation (~11 KB) |
+| `painter_controller.py` | Substance Painter API wrapper |
+| `async_utils.py` | Qt worker thread + signal plumbing |
+| `dependency_manager.py` | Runtime dependency loading |
+| `diagnostics_dialog.py` | In-Painter diagnostics panel |
+| `settings_dialog.py` | Tabbed settings UI |
+| `settings_schema.py` | Settings key definitions and defaults |
+| `qt_utils.py` | Qt helper utilities |
+| `blender_auto_unwrap.py` | Blender background-mode UV unwrap script |
+| `plugin_info.py` | Version/metadata constants |
+
+## Key Entry Points
+
+- `RemixConnectorPlugin.pull_from_remix()` — imports mesh + creates Painter project
+- `RemixConnectorPlugin.push_to_remix()` — exports textures → ingest → update Remix material
+- `RemixConnectorPlugin.force_push_to_remix()` — relinks to new material hash + push
+- `RemixConnectorPlugin.import_textures_from_remix()` — pulls existing textures from linked material
+
+## Network / TLS Policy
+
+All HTTP calls go through `RemixAPIClient.make_request()`. TLS verification:
+- **Disabled** (`verify=False`) for `localhost` / `127.0.0.1` / `[::1]` — Remix runs locally over HTTP
+- **Enabled** (`verify=True`) for any non-loopback host
+
+Do NOT add direct `requests.get/post` calls outside `make_request()`. All new endpoints
+must use the method to preserve retry logic and TLS policy.
+
+## texconv.exe Pipeline
+
+`texture_processor.py` shells out to `texconv.exe` (bundled in repo root).
+- Hard timeout: 180 s (`TEXCONV_TIMEOUT_SECONDS`)
+- Blender unwrap timeout: 900 s (`BLENDER_TIMEOUT_SECONDS`)
+- License: DirectXTex (MIT) — see `THIRD_PARTY_LICENSES.md`
+
+## Install / Setup
+
+No build step. Copy the plugin folder into Painter's `python/plugins/` directory.
+
+## Running Tests
+
+```bash
+python -m pytest tests/
+```
+
+## Known PRs Pending Review
+
+- **PR #1** (stale 2025-08): Metallic/Roughness vs Specular/Glossiness workflow toggle — rebase candidate
+- **PR #2**: Production hardening — thread-safety, lifecycle, timeouts — needs final review

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -29,13 +29,22 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
-**Action required:** Run `texconv.exe /?` to confirm the exact version string and update
-this file with the build date/version. Match against a released tag from
-[DirectXTex releases](https://github.com/microsoft/DirectXTex/releases).
+**Version:** Run `texconv.exe /?` to confirm the exact version string and match
+against a released tag from [DirectXTex releases](https://github.com/microsoft/DirectXTex/releases).
+Update this file with the build date/version once confirmed.
 
 ---
 
 ## requests (Python)
 
 **License:** Apache License 2.0  
-Installed via pip at runtime; not bundled with this plugin.
+**Bundled at:** `_vendor/requests/` (loaded via `dependency_manager.ensure_dependencies_installed()`)  
+Not installed via pip at runtime — the plugin ships its own vendored copy.
+
+---
+
+## Pillow (Python)
+
+**License:** HPND (Historical Permission Notice and Disclaimer)  
+May be bundled under `_vendor/` — check `dependency_manager.py` for the full
+list of vendored packages and verify this file covers all of them.

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,41 @@
+# Third-Party Licenses
+
+## texconv.exe
+
+**Source:** [DirectXTex](https://github.com/microsoft/DirectXTex)  
+**License:** MIT License
+
+```
+MIT License
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+**Action required:** Run `texconv.exe /?` to confirm the exact version string and update
+this file with the build date/version. Match against a released tag from
+[DirectXTex releases](https://github.com/microsoft/DirectXTex/releases).
+
+---
+
+## requests (Python)
+
+**License:** Apache License 2.0  
+Installed via pip at runtime; not bundled with this plugin.

--- a/tests/test_remix_api.py
+++ b/tests/test_remix_api.py
@@ -1,0 +1,138 @@
+"""Tests for remix_api.py — TLS policy and retry coverage."""
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from remix_api import RemixAPIClient
+
+
+def _make_client(base_url="http://localhost:8011"):
+    settings = {"api_base_url": base_url}
+    return RemixAPIClient(settings_getter=lambda: settings, logger=MagicMock())
+
+
+def _mock_response(status=200, body=None):
+    r = MagicMock()
+    r.status_code = status
+    r.content = b"{}"
+    r.text = "{}"
+    r.json.return_value = body or {}
+    return r
+
+
+class TestTLSPolicy(unittest.TestCase):
+    """make_request must apply verify=False for loopback and verify=True for remote."""
+
+    def _capture_verify(self, base_url):
+        client = _make_client(base_url)
+        s = client._get_session()
+        captured = {}
+        mock_resp = _mock_response()
+        with patch.object(s, "request", return_value=mock_resp) as m:
+            client.make_request("GET", "/test", retries=1)
+            _, kwargs = m.call_args
+            captured["verify"] = kwargs.get("verify")
+        return captured
+
+    def test_localhost_uses_verify_false(self):
+        result = self._capture_verify("http://localhost:8011")
+        self.assertFalse(result["verify"])
+
+    def test_127_uses_verify_false(self):
+        result = self._capture_verify("http://127.0.0.1:8011")
+        self.assertFalse(result["verify"])
+
+    def test_remote_host_uses_verify_true(self):
+        result = self._capture_verify("https://remix.example.com:8011")
+        self.assertTrue(result["verify"])
+
+    def test_explicit_verify_true_overrides_localhost(self):
+        client = _make_client("http://localhost:8011")
+        s = client._get_session()
+        mock_resp = _mock_response()
+        with patch.object(s, "request", return_value=mock_resp) as m:
+            client.make_request("GET", "/test", retries=1, verify_ssl=True)
+            _, kwargs = m.call_args
+            self.assertTrue(kwargs.get("verify"))
+
+
+class TestRetryLogic(unittest.TestCase):
+    def test_retries_on_connection_error(self):
+        import requests as req_lib
+        client = _make_client()
+        s = client._get_session()
+        call_count = [0]
+
+        def side_effect(*a, **kw):
+            call_count[0] += 1
+            raise req_lib.exceptions.ConnectionError("refused")
+
+        with patch.object(s, "request", side_effect=side_effect):
+            with patch("time.sleep"):
+                result = client.make_request("GET", "/test", retries=3)
+        self.assertEqual(call_count[0], 3)
+        self.assertFalse(result["success"])
+
+    def test_no_retry_on_400(self):
+        client = _make_client()
+        s = client._get_session()
+        call_count = [0]
+
+        def side_effect(*a, **kw):
+            call_count[0] += 1
+            r = _mock_response(400)
+            r.json.side_effect = ValueError
+            return r
+
+        with patch.object(s, "request", side_effect=side_effect):
+            result = client.make_request("GET", "/test", retries=3)
+        self.assertEqual(call_count[0], 1, "4xx must not retry")
+        self.assertFalse(result["success"])
+
+    def test_retries_on_429(self):
+        client = _make_client()
+        s = client._get_session()
+        call_count = [0]
+
+        def side_effect(*a, **kw):
+            call_count[0] += 1
+            r = _mock_response(429)
+            r.json.side_effect = ValueError
+            return r
+
+        with patch.object(s, "request", side_effect=side_effect):
+            with patch("time.sleep"):
+                result = client.make_request("GET", "/test", retries=3)
+        self.assertGreater(call_count[0], 1, "429 should trigger retries")
+
+    def test_success_on_first_attempt(self):
+        client = _make_client()
+        s = client._get_session()
+        with patch.object(s, "request", return_value=_mock_response(200)):
+            result = client.make_request("GET", "/test")
+        self.assertTrue(result["success"])
+        self.assertEqual(result["status_code"], 200)
+
+
+class TestPing(unittest.TestCase):
+    def test_ping_success(self):
+        client = _make_client()
+        s = client._get_session()
+        with patch.object(s, "request", return_value=_mock_response(200)):
+            ok, msg = client.ping()
+        self.assertTrue(ok)
+
+    def test_ping_failure(self):
+        import requests as req_lib
+        client = _make_client()
+        s = client._get_session()
+        with patch.object(s, "request", side_effect=req_lib.exceptions.ConnectionError("refused")):
+            ok, msg = client.ping()
+        self.assertFalse(ok)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_remix_api.py
+++ b/tests/test_remix_api.py
@@ -4,9 +4,20 @@ import sys
 import unittest
 from unittest.mock import patch, MagicMock
 
+# Inject a mock requests module before importing remix_api so these tests run
+# in environments where requests is not installed (e.g. minimal CI images).
+# remix_api treats requests as optional and guards all usage behind _get_session().
+_req_mock = MagicMock()
+_ConnErr = type("ConnectionError", (OSError,), {})
+_Timeout = type("Timeout", (OSError,), {})
+_req_mock.exceptions.ConnectionError = _ConnErr
+_req_mock.exceptions.Timeout = _Timeout
+_req_mock.exceptions.RequestException = type("RequestException", (OSError,), {})
+sys.modules.setdefault("requests", _req_mock)
+
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-from remix_api import RemixAPIClient
+from remix_api import RemixAPIClient  # noqa: E402
 
 
 def _make_client(base_url="http://localhost:8011"):
@@ -23,54 +34,57 @@ def _mock_response(status=200, body=None):
     return r
 
 
+def _mock_session():
+    """Return a mock session that make_request can call .request() on."""
+    return MagicMock()
+
+
 class TestTLSPolicy(unittest.TestCase):
     """make_request must apply verify=False for loopback and verify=True for remote."""
 
     def _capture_verify(self, base_url):
         client = _make_client(base_url)
-        s = client._get_session()
-        captured = {}
-        mock_resp = _mock_response()
-        with patch.object(s, "request", return_value=mock_resp) as m:
+        sess = _mock_session()
+        sess.request.return_value = _mock_response()
+        with patch.object(client, "_get_session", return_value=sess):
             client.make_request("GET", "/test", retries=1)
-            _, kwargs = m.call_args
-            captured["verify"] = kwargs.get("verify")
-        return captured
+        _, kwargs = sess.request.call_args
+        return kwargs.get("verify")
 
     def test_localhost_uses_verify_false(self):
-        result = self._capture_verify("http://localhost:8011")
-        self.assertFalse(result["verify"])
+        self.assertFalse(self._capture_verify("http://localhost:8011"))
 
     def test_127_uses_verify_false(self):
-        result = self._capture_verify("http://127.0.0.1:8011")
-        self.assertFalse(result["verify"])
+        self.assertFalse(self._capture_verify("http://127.0.0.1:8011"))
+
+    def test_ipv6_loopback_uses_verify_false(self):
+        self.assertFalse(self._capture_verify("http://[::1]:8011"))
 
     def test_remote_host_uses_verify_true(self):
-        result = self._capture_verify("https://remix.example.com:8011")
-        self.assertTrue(result["verify"])
+        self.assertTrue(self._capture_verify("https://remix.example.com:8011"))
 
     def test_explicit_verify_true_overrides_localhost(self):
         client = _make_client("http://localhost:8011")
-        s = client._get_session()
-        mock_resp = _mock_response()
-        with patch.object(s, "request", return_value=mock_resp) as m:
+        sess = _mock_session()
+        sess.request.return_value = _mock_response()
+        with patch.object(client, "_get_session", return_value=sess):
             client.make_request("GET", "/test", retries=1, verify_ssl=True)
-            _, kwargs = m.call_args
-            self.assertTrue(kwargs.get("verify"))
+        _, kwargs = sess.request.call_args
+        self.assertTrue(kwargs.get("verify"))
 
 
 class TestRetryLogic(unittest.TestCase):
     def test_retries_on_connection_error(self):
-        import requests as req_lib
         client = _make_client()
-        s = client._get_session()
+        sess = _mock_session()
         call_count = [0]
 
         def side_effect(*a, **kw):
             call_count[0] += 1
-            raise req_lib.exceptions.ConnectionError("refused")
+            raise _ConnErr("refused")
 
-        with patch.object(s, "request", side_effect=side_effect):
+        sess.request.side_effect = side_effect
+        with patch.object(client, "_get_session", return_value=sess):
             with patch("time.sleep"):
                 result = client.make_request("GET", "/test", retries=3)
         self.assertEqual(call_count[0], 3)
@@ -78,7 +92,7 @@ class TestRetryLogic(unittest.TestCase):
 
     def test_no_retry_on_400(self):
         client = _make_client()
-        s = client._get_session()
+        sess = _mock_session()
         call_count = [0]
 
         def side_effect(*a, **kw):
@@ -87,14 +101,15 @@ class TestRetryLogic(unittest.TestCase):
             r.json.side_effect = ValueError
             return r
 
-        with patch.object(s, "request", side_effect=side_effect):
+        sess.request.side_effect = side_effect
+        with patch.object(client, "_get_session", return_value=sess):
             result = client.make_request("GET", "/test", retries=3)
         self.assertEqual(call_count[0], 1, "4xx must not retry")
         self.assertFalse(result["success"])
 
     def test_retries_on_429(self):
         client = _make_client()
-        s = client._get_session()
+        sess = _mock_session()
         call_count = [0]
 
         def side_effect(*a, **kw):
@@ -103,15 +118,17 @@ class TestRetryLogic(unittest.TestCase):
             r.json.side_effect = ValueError
             return r
 
-        with patch.object(s, "request", side_effect=side_effect):
+        sess.request.side_effect = side_effect
+        with patch.object(client, "_get_session", return_value=sess):
             with patch("time.sleep"):
                 result = client.make_request("GET", "/test", retries=3)
         self.assertGreater(call_count[0], 1, "429 should trigger retries")
 
     def test_success_on_first_attempt(self):
         client = _make_client()
-        s = client._get_session()
-        with patch.object(s, "request", return_value=_mock_response(200)):
+        sess = _mock_session()
+        sess.request.return_value = _mock_response(200)
+        with patch.object(client, "_get_session", return_value=sess):
             result = client.make_request("GET", "/test")
         self.assertTrue(result["success"])
         self.assertEqual(result["status_code"], 200)
@@ -120,16 +137,22 @@ class TestRetryLogic(unittest.TestCase):
 class TestPing(unittest.TestCase):
     def test_ping_success(self):
         client = _make_client()
-        s = client._get_session()
-        with patch.object(s, "request", return_value=_mock_response(200)):
+        sess = _mock_session()
+        sess.request.return_value = _mock_response(200)
+        with patch.object(client, "_get_session", return_value=sess):
             ok, msg = client.ping()
         self.assertTrue(ok)
+        # Verify ping targets the expected stagecraft project endpoint
+        call_args = sess.request.call_args
+        positional = call_args[0] if call_args[0] else ()
+        url = positional[1] if len(positional) > 1 else call_args[1].get("url", "")
+        self.assertIn("/stagecraft/project/", url)
 
     def test_ping_failure(self):
-        import requests as req_lib
         client = _make_client()
-        s = client._get_session()
-        with patch.object(s, "request", side_effect=req_lib.exceptions.ConnectionError("refused")):
+        sess = _mock_session()
+        sess.request.side_effect = _ConnErr("refused")
+        with patch.object(client, "_get_session", return_value=sess):
             ok, msg = client.ping()
         self.assertFalse(ok)
 

--- a/tests/test_texture_processor.py
+++ b/tests/test_texture_processor.py
@@ -1,0 +1,157 @@
+"""Tests for texture_processor.py DDS pipeline."""
+import os
+import sys
+import tempfile
+import shutil
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from texture_processor import TextureProcessor, TEXCONV_TIMEOUT_SECONDS, BLENDER_TIMEOUT_SECONDS
+
+
+def _make_processor(settings=None):
+    settings = settings or {}
+    return TextureProcessor(settings_getter=lambda: settings, logger=MagicMock())
+
+
+class TestSanitizeFilename(unittest.TestCase):
+    def test_strips_illegal_chars(self):
+        tp = _make_processor()
+        result = tp._sanitize_filename_stem("foo<bar>:baz")
+        for ch in "<>:":
+            self.assertNotIn(ch, result)
+
+    def test_truncates_long_names(self):
+        tp = _make_processor()
+        result = tp._sanitize_filename_stem("a" * 200)
+        self.assertLessEqual(len(result), 120)
+
+    def test_empty_returns_empty(self):
+        self.assertEqual(_make_processor()._sanitize_filename_stem(""), "")
+
+
+class TestStripKnownTextureExtensions(unittest.TestCase):
+    def test_strips_dds(self):
+        self.assertEqual(TextureProcessor._strip_known_texture_extensions("foo.dds"), "foo")
+
+    def test_strips_rtex_dds(self):
+        self.assertEqual(TextureProcessor._strip_known_texture_extensions("foo.rtex.dds"), "foo")
+
+    def test_strips_png(self):
+        self.assertEqual(TextureProcessor._strip_known_texture_extensions("bar.png"), "bar")
+
+    def test_handles_windows_path(self):
+        result = TextureProcessor._strip_known_texture_extensions(r"C:\textures\foo.dds")
+        self.assertEqual(result, "foo")
+
+
+class TestStripIngestChannelSuffix(unittest.TestCase):
+    def test_strips_single_letter_suffixes(self):
+        for letter in "anrmheo":
+            self.assertEqual(
+                TextureProcessor._strip_ingest_channel_suffix(f"foo.{letter}"),
+                "foo",
+                msg=f"expected suffix .{letter} to be stripped",
+            )
+
+    def test_leaves_no_suffix(self):
+        self.assertEqual(TextureProcessor._strip_ingest_channel_suffix("foo"), "foo")
+
+    def test_leaves_multi_char_suffix(self):
+        self.assertEqual(TextureProcessor._strip_ingest_channel_suffix("foo.ab"), "foo.ab")
+
+
+class TestConvertDdsToPng(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.tp = _make_processor()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_raises_if_texconv_missing(self):
+        with self.assertRaises(RuntimeError) as ctx:
+            self.tp.convert_dds_to_png("/nonexistent/texconv.exe", "/some/file.dds", "output")
+        self.assertIn("texconv.exe", str(ctx.exception))
+
+    def test_raises_if_dds_missing(self):
+        fake_texconv = os.path.join(self.tmpdir, "texconv.exe")
+        open(fake_texconv, "w").close()
+        with self.assertRaises(RuntimeError) as ctx:
+            self.tp.convert_dds_to_png(fake_texconv, "/nonexistent/foo.dds", "foo")
+        self.assertIn("not found", str(ctx.exception))
+
+    @patch("subprocess.run")
+    def test_raises_on_nonzero_returncode(self, mock_run):
+        fake_texconv = os.path.join(self.tmpdir, "texconv.exe")
+        fake_dds = os.path.join(self.tmpdir, "foo.dds")
+        open(fake_texconv, "w").close()
+        open(fake_dds, "w").close()
+        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="error detail")
+        with self.assertRaises(RuntimeError) as ctx:
+            self.tp.convert_dds_to_png(fake_texconv, fake_dds, "foo")
+        self.assertIn("texconv failed", str(ctx.exception))
+
+    @patch("subprocess.run")
+    def test_raises_on_timeout(self, mock_run):
+        import subprocess
+        fake_texconv = os.path.join(self.tmpdir, "texconv.exe")
+        fake_dds = os.path.join(self.tmpdir, "foo.dds")
+        open(fake_texconv, "w").close()
+        open(fake_dds, "w").close()
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="texconv", timeout=TEXCONV_TIMEOUT_SECONDS)
+        with self.assertRaises(RuntimeError) as ctx:
+            self.tp.convert_dds_to_png(fake_texconv, fake_dds, "foo")
+        self.assertIn("timed out", str(ctx.exception))
+        self.assertIn(str(TEXCONV_TIMEOUT_SECONDS), str(ctx.exception))
+
+    @patch("subprocess.run")
+    def test_raises_if_output_missing_after_success(self, mock_run):
+        fake_texconv = os.path.join(self.tmpdir, "texconv.exe")
+        fake_dds = os.path.join(self.tmpdir, "foo.dds")
+        open(fake_texconv, "w").close()
+        open(fake_dds, "w").close()
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        with self.assertRaises(RuntimeError) as ctx:
+            self.tp.convert_dds_to_png(fake_texconv, fake_dds, "foo")
+        self.assertIn("output missing", str(ctx.exception))
+
+    @patch("subprocess.run")
+    def test_success_returns_output_path(self, mock_run):
+        fake_texconv = os.path.join(self.tmpdir, "texconv.exe")
+        fake_dds = os.path.join(self.tmpdir, "foo.dds")
+        expected_png = os.path.join(self.tmpdir, "foo.png")
+        open(fake_texconv, "w").close()
+        open(fake_dds, "w").close()
+        open(expected_png, "w").close()
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        result = self.tp.convert_dds_to_png(fake_texconv, fake_dds, "foo")
+        self.assertEqual(result, expected_png)
+
+
+class TestChooseNonOverwritingRoot(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.tp = _make_processor()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_returns_desired_root_when_no_conflict(self):
+        result = self.tp.choose_non_overwriting_root("mymat", self.tmpdir)
+        self.assertEqual(result, "mymat")
+
+    def test_appends_index_on_conflict(self):
+        open(os.path.join(self.tmpdir, "mymat.dds"), "w").close()
+        result = self.tp.choose_non_overwriting_root("mymat", self.tmpdir)
+        self.assertEqual(result, "mymat_1")
+
+    def test_returns_desired_when_ingest_dir_missing(self):
+        result = self.tp.choose_non_overwriting_root("foo", "/nonexistent/dir")
+        self.assertEqual(result, "foo")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Addresses issues tracked in skurtyyskirts/TombRaiderLegendRTX- (#113–#118):

- **CLAUDE.md** (#115): Added module map for post-v0.5.0 split, TLS policy, texconv pipeline, known stale PRs (#1, #2)
- **THIRD_PARTY_LICENSES.md** (#117): Documents texconv.exe provenance (DirectXTex by Microsoft, MIT license)
- **tests/test_texture_processor.py** (#116): Unit tests for `_sanitize_filename_stem`, `_strip_known_texture_extensions`, `convert_dds_to_png`, `choose_non_overwriting_root`
- **tests/test_remix_api.py** (#116, #118): TLS policy tests (localhost → `verify=False`, remote → `verify=True`), retry logic tests (ConnectionError retries 3×, 400 fast-fails, 429 retries), ping path tests

## Test plan

- [ ] `pytest tests/test_texture_processor.py` — all cases pass (with texconv mocked)
- [ ] `pytest tests/test_remix_api.py` — TLS and retry assertions pass
- [ ] Confirm `THIRD_PARTY_LICENSES.md` matches actual texconv.exe version via `texconv.exe /?`
- [ ] Review CLAUDE.md module map against actual source tree

---
_Generated by [Claude Code](https://claude.ai/code/session_01NSrzmnU5UYLWJyAKvC4A1v)_