### PR TITLE
🧹 Remove unused sys import in painter_controller.py

### DIFF
--- a/painter_controller.py
+++ b/painter_controller.py
@@ -1,4 +1,3 @@
-import sys
 try:
     import substance_painter.textureset
     import substance_painter.resource

--- a/tests/test_remix_api.py
+++ b/tests/test_remix_api.py
@@ -8,11 +8,12 @@ from unittest.mock import patch, MagicMock
 # in environments where requests is not installed (e.g. minimal CI images).
 # remix_api treats requests as optional and guards all usage behind _get_session().
 _req_mock = MagicMock()
-_ConnErr = type("ConnectionError", (OSError,), {})
-_Timeout = type("Timeout", (OSError,), {})
+_ReqEx = type("RequestException", (OSError,), {})
+_ConnErr = type("ConnectionError", (_ReqEx,), {})
+_Timeout = type("Timeout", (_ReqEx,), {})
+_req_mock.exceptions.RequestException = _ReqEx
 _req_mock.exceptions.ConnectionError = _ConnErr
 _req_mock.exceptions.Timeout = _Timeout
-_req_mock.exceptions.RequestException = type("RequestException", (OSError,), {})
 sys.modules.setdefault("requests", _req_mock)
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))


### PR DESCRIPTION
🎯 **What:** Removed unused `sys` import from `painter_controller.py`.
💡 **Why:** To improve code maintainability and reduce clutter, addressing a minor code health issue.
✅ **Verification:** Ran test suite using `python3 -m unittest discover tests` successfully (including a minor mock test fix to get it passing cleanly).
✨ **Result:** Improved file clarity without any behavioral change.

---
*PR created automatically by Jules for task [1191608003648701464](https://jules.google.com/task/1191608003648701464) started by @skurtyyskirts*