### PR TITLE
🧪 [Testing Improvement] Add tests for _force_push_root_conflicts

### DIFF
--- a/tests/test_remix_api.py
+++ b/tests/test_remix_api.py
@@ -8,11 +8,13 @@ from unittest.mock import patch, MagicMock
 # in environments where requests is not installed (e.g. minimal CI images).
 # remix_api treats requests as optional and guards all usage behind _get_session().
 _req_mock = MagicMock()
-_ConnErr = type("ConnectionError", (OSError,), {})
-_Timeout = type("Timeout", (OSError,), {})
+class _ReqErr(OSError): pass
+_req_mock.exceptions.RequestException = _ReqErr
+class _ConnErr(_ReqErr): pass
+class _Timeout(_ReqErr): pass
+
 _req_mock.exceptions.ConnectionError = _ConnErr
 _req_mock.exceptions.Timeout = _Timeout
-_req_mock.exceptions.RequestException = type("RequestException", (OSError,), {})
 sys.modules.setdefault("requests", _req_mock)
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))

--- a/tests/test_texture_processor.py
+++ b/tests/test_texture_processor.py
@@ -153,5 +153,69 @@ class TestChooseNonOverwritingRoot(unittest.TestCase):
         self.assertEqual(result, "foo")
 
 
+class TestForcePushRootConflicts(unittest.TestCase):
+    def setUp(self):
+        self.tp = _make_processor()
+
+    @patch("os.path.isdir")
+    def test_invalid_inputs(self, mock_isdir):
+        mock_isdir.return_value = False
+        self.assertFalse(self.tp._force_push_root_conflicts("", "/some/dir"))
+        self.assertFalse(self.tp._force_push_root_conflicts("root", ""))
+        self.assertFalse(self.tp._force_push_root_conflicts(None, "/some/dir"))
+        self.assertFalse(self.tp._force_push_root_conflicts("root", None))
+
+        # Test valid inputs but isdir returns False
+        self.assertFalse(self.tp._force_push_root_conflicts("root", "/some/dir"))
+
+    @patch("os.path.isdir")
+    @patch("os.listdir")
+    def test_exact_matches(self, mock_listdir, mock_isdir):
+        mock_isdir.return_value = True
+
+        mock_listdir.return_value = ["mymat.dds"]
+        self.assertTrue(self.tp._force_push_root_conflicts("mymat", "/dir"))
+
+        mock_listdir.return_value = ["MYMAT.rtex.dds"]
+        self.assertTrue(self.tp._force_push_root_conflicts("mymat", "/dir"))
+
+        mock_listdir.return_value = ["MyMat.dds"]
+        self.assertTrue(self.tp._force_push_root_conflicts("mymat", "/dir"))
+
+    @patch("os.path.isdir")
+    @patch("os.listdir")
+    def test_matches_with_separators(self, mock_listdir, mock_isdir):
+        mock_isdir.return_value = True
+
+        mock_listdir.return_value = ["mymat_albedo.dds"]
+        self.assertTrue(self.tp._force_push_root_conflicts("mymat", "/dir"))
+
+        mock_listdir.return_value = ["mymat-normal.dds"]
+        self.assertTrue(self.tp._force_push_root_conflicts("mymat", "/dir"))
+
+        mock_listdir.return_value = ["mymat.1.dds"]
+        self.assertTrue(self.tp._force_push_root_conflicts("mymat", "/dir"))
+
+    @patch("os.path.isdir")
+    @patch("os.listdir")
+    def test_ignores_non_dds_files(self, mock_listdir, mock_isdir):
+        mock_isdir.return_value = True
+        mock_listdir.return_value = ["mymat.png", "mymat.jpg", "mymat_albedo.tga"]
+        self.assertFalse(self.tp._force_push_root_conflicts("mymat", "/dir"))
+
+    @patch("os.path.isdir")
+    @patch("os.listdir")
+    def test_ignores_prefix_without_separator(self, mock_listdir, mock_isdir):
+        mock_isdir.return_value = True
+        mock_listdir.return_value = ["mymaterial.dds", "mymatter.rtex.dds"]
+        self.assertFalse(self.tp._force_push_root_conflicts("mymat", "/dir"))
+
+    @patch("os.path.isdir")
+    @patch("os.listdir")
+    def test_handles_os_exceptions(self, mock_listdir, mock_isdir):
+        mock_isdir.return_value = True
+        mock_listdir.side_effect = PermissionError("Access denied")
+        self.assertFalse(self.tp._force_push_root_conflicts("mymat", "/dir"))
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
🎯 **What:** Missing test coverage for `_force_push_root_conflicts` in `texture_processor.py`. Also added missing exception inheritance for the mock `requests` module in `test_remix_api.py`.
📊 **Coverage:** Unit tests cover invalid inputs, exact matches, matching prefixes, ignored non-DDS extensions, ignored common prefixes with no separators, and OS exception handling (mocked via `os.path.isdir` and `os.listdir`).
✨ **Result:** Improved overall codebase confidence by ensuring the conflict resolution method works as intended. Tests correctly catch bugs inside `_force_push_root_conflicts`.

---
*PR created automatically by Jules for task [14489790343650538502](https://jules.google.com/task/14489790343650538502) started by @skurtyyskirts*