### PR TITLE
🧹 [code health improvement] Remove unused _strip_ingest_channel_suffix function

### DIFF
--- a/tests/test_remix_api.py
+++ b/tests/test_remix_api.py
@@ -8,11 +8,12 @@ from unittest.mock import patch, MagicMock
 # in environments where requests is not installed (e.g. minimal CI images).
 # remix_api treats requests as optional and guards all usage behind _get_session().
 _req_mock = MagicMock()
-_ConnErr = type("ConnectionError", (OSError,), {})
-_Timeout = type("Timeout", (OSError,), {})
+_ReqExc = type("RequestException", (OSError,), {})
+_ConnErr = type("ConnectionError", (_ReqExc,), {})
+_Timeout = type("Timeout", (_ReqExc,), {})
 _req_mock.exceptions.ConnectionError = _ConnErr
 _req_mock.exceptions.Timeout = _Timeout
-_req_mock.exceptions.RequestException = type("RequestException", (OSError,), {})
+_req_mock.exceptions.RequestException = _ReqExc
 sys.modules.setdefault("requests", _req_mock)
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))

--- a/tests/test_texture_processor.py
+++ b/tests/test_texture_processor.py
@@ -47,21 +47,6 @@ class TestStripKnownTextureExtensions(unittest.TestCase):
         self.assertEqual(result, "foo")
 
 
-class TestStripIngestChannelSuffix(unittest.TestCase):
-    def test_strips_single_letter_suffixes(self):
-        for letter in "anrmheo":
-            self.assertEqual(
-                TextureProcessor._strip_ingest_channel_suffix(f"foo.{letter}"),
-                "foo",
-                msg=f"expected suffix .{letter} to be stripped",
-            )
-
-    def test_leaves_no_suffix(self):
-        self.assertEqual(TextureProcessor._strip_ingest_channel_suffix("foo"), "foo")
-
-    def test_leaves_multi_char_suffix(self):
-        self.assertEqual(TextureProcessor._strip_ingest_channel_suffix("foo.ab"), "foo.ab")
-
 
 class TestConvertDdsToPng(unittest.TestCase):
     def setUp(self):

--- a/texture_processor.py
+++ b/texture_processor.py
@@ -62,11 +62,6 @@ class TextureProcessor:
             stem = os.path.splitext(stem)[0]
         return stem
 
-    @staticmethod
-    def _strip_ingest_channel_suffix(stem):
-        if not stem: return ""
-        return re.sub(r"\.[armhnoaodse]$", "", str(stem), flags=re.IGNORECASE)
-
     def convert_dds_to_png(self, texconv_exe, dds_file, output_png_target_name_base, output_dir_override=None):
         if not texconv_exe or not os.path.isfile(texconv_exe): 
             raise RuntimeError(f"texconv.exe path is not configured or invalid: {texconv_exe}")


### PR DESCRIPTION
🎯 **What:** Removed the unused `_strip_ingest_channel_suffix` method from `texture_processor.py` and its corresponding tests in `tests/test_texture_processor.py`. Also fixed broken mock exception hierarchy in `tests/test_remix_api.py`.
💡 **Why:** Reduces dead code, improving codebase clarity and maintainability. Fixed mock exceptions to ensure `test_remix_api.py` actually catches mock errors during retry testing.
✅ **Verification:** Ran `python3 -m unittest discover tests` successfully; all 27 tests pass.
✨ **Result:** A cleaner codebase and fixed unit tests.

---
*PR created automatically by Jules for task [13795776741848458098](https://jules.google.com/task/13795776741848458098) started by @skurtyyskirts*