### PR TITLE
🧪 [testing improvement] Add fallback sequence testing for PainterController

### DIFF
--- a/tests/test_painter_controller.py
+++ b/tests/test_painter_controller.py
@@ -1,0 +1,117 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from painter_controller import PainterController
+
+class TestAssignTextureToChannel(unittest.TestCase):
+    def setUp(self):
+        self.logger = MagicMock()
+        self.controller = PainterController(self.logger)
+
+    def test_global_set_channel_texture_resource(self):
+        with patch('painter_controller.substance_painter') as mock_sp:
+            mock_channel = MagicMock()
+            mock_rid = "resource_id"
+
+            # Setup global method to succeed
+            mock_sp.textureset.set_channel_texture_resource = MagicMock()
+
+            result = self.controller.assign_texture_to_channel(mock_channel, mock_rid)
+
+            self.assertTrue(result)
+            mock_sp.textureset.set_channel_texture_resource.assert_called_once()
+
+    def test_instance_methods_fallback(self):
+        with patch('painter_controller.substance_painter') as mock_sp:
+            mock_channel = MagicMock()
+            mock_rid = "resource_id"
+
+            # Remove global method to trigger fallback
+            del mock_sp.textureset.set_channel_texture_resource
+
+            # Setup channel instance method
+            mock_channel.set_texture_resource = MagicMock()
+
+            result = self.controller.assign_texture_to_channel(mock_channel, mock_rid)
+
+            self.assertTrue(result)
+            mock_channel.set_texture_resource.assert_called_once()
+
+    def test_stack_methods_fallback(self):
+        with patch('painter_controller.substance_painter') as mock_sp:
+            mock_channel = MagicMock()
+            mock_rid = "resource_id"
+
+            # Remove global and instance methods to trigger fallback
+            del mock_sp.textureset.set_channel_texture_resource
+            mock_channel.set_texture_resource = None
+            mock_channel.setTextureResource = None
+            mock_channel.set_resource = None
+            mock_channel.setResource = None
+            mock_channel.assign_texture = None
+            mock_channel.assignTexture = None
+
+            # Setup stack methods
+            mock_stack = MagicMock()
+            mock_stack.set_channel_texture_resource = MagicMock()
+            mock_channel.stack.return_value = mock_stack
+
+            result = self.controller.assign_texture_to_channel(mock_channel, mock_rid)
+
+            self.assertTrue(result)
+            mock_stack.set_channel_texture_resource.assert_called_once_with(mock_channel, self.controller._coerce_to_resource_id(mock_rid))
+
+    def test_module_level_fallbacks(self):
+        with patch('painter_controller.substance_painter') as mock_sp:
+            mock_channel = MagicMock()
+            mock_rid = "resource_id"
+
+            # Remove global, instance, and stack methods to trigger fallback
+            del mock_sp.textureset.set_channel_texture_resource
+            mock_channel.set_texture_resource = None
+            mock_channel.setTextureResource = None
+            mock_channel.set_resource = None
+            mock_channel.setResource = None
+            mock_channel.assign_texture = None
+            mock_channel.assignTexture = None
+
+            mock_channel.stack.side_effect = AttributeError("No stack")
+
+            # Setup module level fallback
+            mock_sp.textureset.set_channel_resource = MagicMock()
+
+            result = self.controller.assign_texture_to_channel(mock_channel, mock_rid)
+
+            self.assertTrue(result)
+            mock_sp.textureset.set_channel_resource.assert_called_once()
+
+    def test_all_fallbacks_fail(self):
+        with patch('painter_controller.substance_painter') as mock_sp:
+            mock_channel = MagicMock()
+            mock_rid = "resource_id"
+
+            # Remove all fallback methods
+            del mock_sp.textureset.set_channel_texture_resource
+            mock_channel.set_texture_resource = None
+            mock_channel.setTextureResource = None
+            mock_channel.set_resource = None
+            mock_channel.setResource = None
+            mock_channel.assign_texture = None
+            mock_channel.assignTexture = None
+
+            mock_channel.stack.side_effect = AttributeError("No stack")
+
+            mock_sp.textureset.set_channel_resource = None
+            mock_sp.textureset.set_channel_texture = None
+            mock_sp.textureset.set_channel_map = None
+
+            result = self.controller.assign_texture_to_channel(mock_channel, mock_rid)
+
+            self.assertFalse(result)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_remix_api.py
+++ b/tests/test_remix_api.py
@@ -8,11 +8,12 @@ from unittest.mock import patch, MagicMock
 # in environments where requests is not installed (e.g. minimal CI images).
 # remix_api treats requests as optional and guards all usage behind _get_session().
 _req_mock = MagicMock()
-_ConnErr = type("ConnectionError", (OSError,), {})
-_Timeout = type("Timeout", (OSError,), {})
+_ReqErr = type("RequestException", (OSError,), {})
+_ConnErr = type("ConnectionError", (_ReqErr,), {})
+_Timeout = type("Timeout", (_ReqErr,), {})
 _req_mock.exceptions.ConnectionError = _ConnErr
 _req_mock.exceptions.Timeout = _Timeout
-_req_mock.exceptions.RequestException = type("RequestException", (OSError,), {})
+_req_mock.exceptions.RequestException = _ReqErr
 sys.modules.setdefault("requests", _req_mock)
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))


### PR DESCRIPTION
🎯 **What:** The `assign_texture_to_channel` method in `painter_controller.py` was missing test coverage for its complex fallback logic.
📊 **Coverage:** The new `tests/test_painter_controller.py` tests cover all five steps of the fallback sequence: the global method, instance methods, stack methods, module-level fallbacks, and the case where all fallbacks fail.
✨ **Result:** The fallback sequence logic in the `PainterController` module is now properly tested, increasing test reliability for texture assignments. Pre-existing broken test logic for RequestException inheritance was also fixed.

---
*PR created automatically by Jules for task [9371086641772446913](https://jules.google.com/task/9371086641772446913) started by @skurtyyskirts*