### PR TITLE
🧪 Add tests for PainterController texture assignment fallbacks

### DIFF
--- a/tests/test_painter_controller.py
+++ b/tests/test_painter_controller.py
@@ -5,7 +5,8 @@ from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-# We need to mock substance_painter before importing painter_controller
+# painter_controller handles missing substance_painter on import; tests
+# replace painter_controller.substance_painter in setUp.
 import painter_controller
 from painter_controller import PainterController
 

--- a/tests/test_painter_controller.py
+++ b/tests/test_painter_controller.py
@@ -1,0 +1,153 @@
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+# We need to mock substance_painter before importing painter_controller
+import painter_controller
+from painter_controller import PainterController
+
+class TestPainterControllerAssignTexture(unittest.TestCase):
+    def setUp(self):
+        self.logger = MagicMock()
+        self.controller = PainterController(self.logger)
+
+        # Reset the mock for each test
+        painter_controller.substance_painter = MagicMock()
+        painter_controller.substance_painter.textureset = MagicMock()
+        painter_controller.substance_painter.resource = MagicMock()
+
+        # Consistent resource ID mock
+        painter_controller.substance_painter.resource.ResourceID = MagicMock(return_value="mocked_id")
+
+    def test_assign_via_global_textureset_method(self):
+        # 1. Try global set_channel_texture_resource if available
+        channel = MagicMock()
+
+        # Set up the first fallback
+        painter_controller.substance_painter.textureset.set_channel_texture_resource = MagicMock()
+
+        result = self.controller.assign_texture_to_channel(channel, "my_resource")
+
+        self.assertTrue(result)
+        painter_controller.substance_painter.textureset.set_channel_texture_resource.assert_called_once_with(channel, "mocked_id")
+
+    def test_assign_via_channel_instance_method(self):
+        # 2. Instance methods on Channel
+        channel = MagicMock()
+
+        # Disable the first fallback
+        del painter_controller.substance_painter.textureset.set_channel_texture_resource
+
+        # Set up the second fallback
+        channel.set_texture_resource = MagicMock()
+
+        result = self.controller.assign_texture_to_channel(channel, "my_resource")
+
+        self.assertTrue(result)
+        channel.set_texture_resource.assert_called_once_with("mocked_id")
+
+    def test_assign_via_channel_instance_method_alternate(self):
+        # 2. Instance methods on Channel (alternate method name)
+        channel = MagicMock()
+
+        # Disable the first fallback
+        del painter_controller.substance_painter.textureset.set_channel_texture_resource
+
+        # Set up one of the other allowed method names and delete the first one
+        # Because we're using MagicMock, we need to explicitly delete the attributes we don't want to be found
+        # before the one we're testing.
+        del channel.set_texture_resource
+        del channel.setTextureResource
+        del channel.set_resource
+        del channel.setResource
+        channel.assign_texture = MagicMock()
+
+        result = self.controller.assign_texture_to_channel(channel, "my_resource")
+
+        self.assertTrue(result)
+        channel.assign_texture.assert_called_once_with("mocked_id")
+
+    def test_assign_via_stack_method(self):
+        # 3. Stack methods
+        channel = MagicMock()
+        stack = MagicMock()
+        channel.stack = MagicMock(return_value=stack)
+
+        # Disable previous fallbacks
+        del painter_controller.substance_painter.textureset.set_channel_texture_resource
+        for method_name in ['set_texture_resource', 'setTextureResource', 'set_resource', 'setResource', 'assign_texture', 'assignTexture']:
+            delattr(channel, method_name)
+
+        # Set up the third fallback
+        stack.set_channel_texture_resource = MagicMock()
+
+        result = self.controller.assign_texture_to_channel(channel, "my_resource")
+
+        self.assertTrue(result)
+        stack.set_channel_texture_resource.assert_called_once_with(channel, "mocked_id")
+
+    def test_assign_via_module_level_fallback(self):
+        # 4. Module level fallbacks
+        channel = MagicMock()
+
+        # Disable previous fallbacks
+        del painter_controller.substance_painter.textureset.set_channel_texture_resource
+        for method_name in ['set_texture_resource', 'setTextureResource', 'set_resource', 'setResource', 'assign_texture', 'assignTexture']:
+            delattr(channel, method_name)
+        del channel.stack
+
+        # Set up the fourth fallback
+        painter_controller.substance_painter.textureset.set_channel_resource = MagicMock()
+
+        result = self.controller.assign_texture_to_channel(channel, "my_resource")
+
+        self.assertTrue(result)
+        painter_controller.substance_painter.textureset.set_channel_resource.assert_called_once_with(channel, "mocked_id")
+
+    def test_assign_fails_when_all_fallbacks_fail(self):
+        channel = MagicMock()
+
+        # Disable all fallbacks
+        del painter_controller.substance_painter.textureset.set_channel_texture_resource
+        for method_name in ['set_texture_resource', 'setTextureResource', 'set_resource', 'setResource', 'assign_texture', 'assignTexture']:
+            delattr(channel, method_name)
+        del channel.stack
+        for method_name in ['set_channel_resource', 'set_channel_texture', 'set_channel_map']:
+            delattr(painter_controller.substance_painter.textureset, method_name)
+
+        result = self.controller.assign_texture_to_channel(channel, "my_resource")
+
+        self.assertFalse(result)
+
+    def test_exception_in_fallback_continues_to_next(self):
+        channel = MagicMock()
+
+        # Make the first fallback raise an exception
+        painter_controller.substance_painter.textureset.set_channel_texture_resource = MagicMock(side_effect=Exception("Failed"))
+
+        # Make the second fallback work
+        channel.set_texture_resource = MagicMock()
+
+        result = self.controller.assign_texture_to_channel(channel, "my_resource")
+
+        self.assertTrue(result)
+        channel.set_texture_resource.assert_called_once_with("mocked_id")
+
+    def test_coerce_to_resource_id_fallback(self):
+        # Test what happens if substance_painter.resource.ResourceID is not available or raises
+        del painter_controller.substance_painter.resource.ResourceID
+
+        channel = MagicMock()
+        painter_controller.substance_painter.textureset.set_channel_texture_resource = MagicMock()
+
+        result = self.controller.assign_texture_to_channel(channel, "my_resource")
+
+        self.assertTrue(result)
+        # Should be called with the original string since coercion failed
+        painter_controller.substance_painter.textureset.set_channel_texture_resource.assert_called_once_with(channel, "my_resource")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_remix_api.py
+++ b/tests/test_remix_api.py
@@ -8,11 +8,12 @@ from unittest.mock import patch, MagicMock
 # in environments where requests is not installed (e.g. minimal CI images).
 # remix_api treats requests as optional and guards all usage behind _get_session().
 _req_mock = MagicMock()
-_ConnErr = type("ConnectionError", (OSError,), {})
-_Timeout = type("Timeout", (OSError,), {})
+_RequestException = type("RequestException", (OSError,), {})
+_ConnErr = type("ConnectionError", (_RequestException,), {})
+_Timeout = type("Timeout", (_RequestException,), {})
+_req_mock.exceptions.RequestException = _RequestException
 _req_mock.exceptions.ConnectionError = _ConnErr
 _req_mock.exceptions.Timeout = _Timeout
-_req_mock.exceptions.RequestException = type("RequestException", (OSError,), {})
 sys.modules.setdefault("requests", _req_mock)
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))


### PR DESCRIPTION
🎯 **What:** This PR addresses the missing test coverage for texture assignment in `PainterController`. It specifically tests the `assign_texture_to_channel` method, which contains multiple API fallback sequences since the Substance Painter API might differ across versions.

📊 **Coverage:** The following scenarios are now tested:
- Success via `substance_painter.textureset.set_channel_texture_resource`
- Success via channel instance methods (`set_texture_resource` etc.)
- Success via channel stack methods (`stack.set_channel_texture_resource` etc.)
- Success via module level fallbacks (`substance_painter.textureset.set_channel_resource` etc.)
- Graceful handling of exceptions during fallbacks, allowing the next method in sequence to try.
- Expected behavior when all fallbacks fail (returns `False`).
- Edge case where `resource.ResourceID` coercion fails but string assignment is still attempted.
- A small fix to `test_remix_api.py` was also included so that mocked exceptions correctly inherit from the mocked `RequestException`, allowing the full test suite to pass.

✨ **Result:** Test coverage is significantly improved and the complex fallback logic within `PainterController` is now robustly verified to work regardless of the specific Substance Painter environment it's running in.

---
*PR created automatically by Jules for task [9491647398451077741](https://jules.google.com/task/9491647398451077741) started by @skurtyyskirts*