### PR TITLE
🧹 [code health] Remove unimplemented create_project method

### DIFF
--- a/painter_controller.py
+++ b/painter_controller.py
@@ -120,12 +120,4 @@ class PainterController:
         if hasattr(substance_painter.project, 'close'):
             substance_painter.project.close()
 
-    def create_project(self, mesh_file_path, template_path=None, project_settings=None):
-        if hasattr(substance_painter.project, 'create'):
-             # This signature depends on API version, keeping it simple or passing args
-             # The original code likely calls it directly. 
-             # For now, I'll let the main logic call substance_painter directly for complex ops 
-             # unless I wrap them fully.
-             pass
-        pass
 

--- a/tests/test_remix_api.py
+++ b/tests/test_remix_api.py
@@ -8,11 +8,12 @@ from unittest.mock import patch, MagicMock
 # in environments where requests is not installed (e.g. minimal CI images).
 # remix_api treats requests as optional and guards all usage behind _get_session().
 _req_mock = MagicMock()
-_ConnErr = type("ConnectionError", (OSError,), {})
-_Timeout = type("Timeout", (OSError,), {})
+_ReqExc = type("RequestException", (OSError,), {})
+_ConnErr = type("ConnectionError", (_ReqExc,), {})
+_Timeout = type("Timeout", (_ReqExc,), {})
 _req_mock.exceptions.ConnectionError = _ConnErr
 _req_mock.exceptions.Timeout = _Timeout
-_req_mock.exceptions.RequestException = type("RequestException", (OSError,), {})
+_req_mock.exceptions.RequestException = _ReqExc
 sys.modules.setdefault("requests", _req_mock)
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))


### PR DESCRIPTION
🎯 **What:** Removed the empty and unused `create_project` function from `painter_controller.py`. Also fixed an issue in `tests/test_remix_api.py` where mock exceptions weren't inheriting from `RequestException` properly.
💡 **Why:** The method was just a placeholder doing nothing and could cause confusion.
✅ **Verification:** Verified by running `python3 -m unittest discover tests` and checking all 30 tests pass.
✨ **Result:** A cleaner `painter_controller.py` file and functioning test suite.

---
*PR created automatically by Jules for task [9813038291343279678](https://jules.google.com/task/9813038291343279678) started by @skurtyyskirts*