### PR TITLE
🧹 [Code Health] Remove unused `PBR_TO_REMIX_INGEST_VALIDATION_TYPE_MAP` import in `core.py`

### DIFF
--- a/core.py
+++ b/core.py
@@ -12,7 +12,7 @@ import threading
 from . import dependency_manager
 from .qt_utils import QObject, Signal, Slot, QThread, QRunnable, QThreadPool, QtWidgets, QtCore, QT_BINDING
 from .plugin_info import PLUGIN_NAME, PLUGIN_VERSION, PLUGIN_REPO_URL, PLUGIN_DESCRIPTION
-from .remix_api import RemixAPIClient, REMIX_ATTR_SUFFIX_TO_PBR_MAP, PBR_TO_REMIX_INGEST_VALIDATION_TYPE_MAP
+from .remix_api import RemixAPIClient, REMIX_ATTR_SUFFIX_TO_PBR_MAP
 from .texture_processor import TextureProcessor
 from .painter_controller import PainterController
 from .async_utils import Worker

--- a/tests/test_remix_api.py
+++ b/tests/test_remix_api.py
@@ -8,11 +8,12 @@ from unittest.mock import patch, MagicMock
 # in environments where requests is not installed (e.g. minimal CI images).
 # remix_api treats requests as optional and guards all usage behind _get_session().
 _req_mock = MagicMock()
-_ConnErr = type("ConnectionError", (OSError,), {})
-_Timeout = type("Timeout", (OSError,), {})
+_ReqExc = type("RequestException", (OSError,), {})
+_ConnErr = type("ConnectionError", (_ReqExc,), {})
+_Timeout = type("Timeout", (_ReqExc,), {})
 _req_mock.exceptions.ConnectionError = _ConnErr
 _req_mock.exceptions.Timeout = _Timeout
-_req_mock.exceptions.RequestException = type("RequestException", (OSError,), {})
+_req_mock.exceptions.RequestException = _ReqExc
 sys.modules.setdefault("requests", _req_mock)
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))


### PR DESCRIPTION
🎯 **What:** The unused `PBR_TO_REMIX_INGEST_VALIDATION_TYPE_MAP` import was removed from `core.py`.
💡 **Why:** This improves maintainability and readability by keeping the imports list accurate, lean and relevant.
✅ **Verification:** Verified by checking the file contents with `head` and `grep` for the removed import, as well as running the test suite with `python3 -m unittest discover tests`.
✨ **Result:** A cleaner `core.py` without unused imports. A minor bug in test mocking was also patched as an aside, fixing broken tests in the suite.

---
*PR created automatically by Jules for task [17019976760935692443](https://jules.google.com/task/17019976760935692443) started by @skurtyyskirts*