### PR TITLE
🧹 [code health] Remove unused sys import in painter_controller.py

### DIFF
--- a/painter_controller.py
+++ b/painter_controller.py
@@ -1,4 +1,3 @@
-import sys
 try:
     import substance_painter.textureset
     import substance_painter.resource

--- a/tests/test_remix_api.py
+++ b/tests/test_remix_api.py
@@ -8,11 +8,12 @@ from unittest.mock import patch, MagicMock
 # in environments where requests is not installed (e.g. minimal CI images).
 # remix_api treats requests as optional and guards all usage behind _get_session().
 _req_mock = MagicMock()
-_ConnErr = type("ConnectionError", (OSError,), {})
-_Timeout = type("Timeout", (OSError,), {})
+_ReqErr = type("RequestException", (OSError,), {})
+_req_mock.exceptions.RequestException = _ReqErr
+_ConnErr = type("ConnectionError", (_ReqErr,), {})
+_Timeout = type("Timeout", (_ReqErr,), {})
 _req_mock.exceptions.ConnectionError = _ConnErr
 _req_mock.exceptions.Timeout = _Timeout
-_req_mock.exceptions.RequestException = type("RequestException", (OSError,), {})
 sys.modules.setdefault("requests", _req_mock)
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))


### PR DESCRIPTION
🎯 What: Removed the unused `import sys` statement from `painter_controller.py`. Also corrected a minor mock typing issue in `test_remix_api.py` to ensure unit tests run correctly.
💡 Why: Removing unused imports improves codebase cleanliness and maintainability.
✅ Verification: Ran the full test suite using `python3 -m unittest discover tests` and verified that no functionality is broken and no new regressions are introduced.
✨ Result: Code is cleaner and more concise.

---
*PR created automatically by Jules for task [5743617966362732257](https://jules.google.com/task/5743617966362732257) started by @skurtyyskirts*