### PR TITLE
🧹 [Code Health] Remove unused `sys` import in `qt_utils.py`

### DIFF
--- a/qt_utils.py
+++ b/qt_utils.py
@@ -1,5 +1,3 @@
-import sys
-
 # Initialize variables to None
 QtWidgets = None
 QtCore = None

--- a/tests/test_remix_api.py
+++ b/tests/test_remix_api.py
@@ -8,11 +8,12 @@ from unittest.mock import patch, MagicMock
 # in environments where requests is not installed (e.g. minimal CI images).
 # remix_api treats requests as optional and guards all usage behind _get_session().
 _req_mock = MagicMock()
-_ConnErr = type("ConnectionError", (OSError,), {})
-_Timeout = type("Timeout", (OSError,), {})
+_ReqErr = type("RequestException", (OSError,), {})
+_ConnErr = type("ConnectionError", (_ReqErr,), {})
+_Timeout = type("Timeout", (_ReqErr,), {})
 _req_mock.exceptions.ConnectionError = _ConnErr
 _req_mock.exceptions.Timeout = _Timeout
-_req_mock.exceptions.RequestException = type("RequestException", (OSError,), {})
+_req_mock.exceptions.RequestException = _ReqErr
 sys.modules.setdefault("requests", _req_mock)
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))


### PR DESCRIPTION
* 🎯 **What:** Removed the unused `import sys` statement from `qt_utils.py`.
* 💡 **Why:** This is a trivial code hygiene task to remove unused imports, which slightly improves code readability and maintainability.
* ✅ **Verification:** Ran `python3 -m unittest discover tests` successfully after fixing an issue with mocked exceptions inheriting from the wrong base class in `tests/test_remix_api.py`.
* ✨ **Result:** The unused import was successfully removed, and the tests pass reliably.

---
*PR created automatically by Jules for task [4732959088491474685](https://jules.google.com/task/4732959088491474685) started by @skurtyyskirts*