### PR TITLE
🧹 [code health] Remove unused _strip_known_texture_extensions function

### DIFF
--- a/tests/test_texture_processor.py
+++ b/tests/test_texture_processor.py
@@ -32,21 +32,6 @@ class TestSanitizeFilename(unittest.TestCase):
         self.assertEqual(_make_processor()._sanitize_filename_stem(""), "")
 
 
-class TestStripKnownTextureExtensions(unittest.TestCase):
-    def test_strips_dds(self):
-        self.assertEqual(TextureProcessor._strip_known_texture_extensions("foo.dds"), "foo")
-
-    def test_strips_rtex_dds(self):
-        self.assertEqual(TextureProcessor._strip_known_texture_extensions("foo.rtex.dds"), "foo")
-
-    def test_strips_png(self):
-        self.assertEqual(TextureProcessor._strip_known_texture_extensions("bar.png"), "bar")
-
-    def test_handles_windows_path(self):
-        result = TextureProcessor._strip_known_texture_extensions(r"C:\textures\foo.dds")
-        self.assertEqual(result, "foo")
-
-
 class TestStripIngestChannelSuffix(unittest.TestCase):
     def test_strips_single_letter_suffixes(self):
         for letter in "anrmheo":

--- a/texture_processor.py
+++ b/texture_processor.py
@@ -54,15 +54,6 @@ class TextureProcessor:
         return cleaned[:120]
 
     @staticmethod
-    def _strip_known_texture_extensions(texture_path_or_name):
-        if not texture_path_or_name: return ""
-        base = TextureProcessor.safe_basename(str(texture_path_or_name).replace("\\", "/"))
-        stem = os.path.splitext(base)[0]
-        if stem.lower().endswith(".rtex"):
-            stem = os.path.splitext(stem)[0]
-        return stem
-
-    @staticmethod
     def _strip_ingest_channel_suffix(stem):
         if not stem: return ""
         return re.sub(r"\.[armhnoaodse]$", "", str(stem), flags=re.IGNORECASE)


### PR DESCRIPTION
🎯 **What:** Removed the unused static method `_strip_known_texture_extensions` from `TextureProcessor` and its corresponding test class `TestStripKnownTextureExtensions`.
💡 **Why:** The function was unused dead code. Removing it reduces duplication and improves code readability and maintainability.
✅ **Verification:** Ensured functionality is not affected. Ran `pytest tests/test_texture_processor.py` successfully and verified that the test suite continues to pass.
✨ **Result:** Cleaned up dead code and associated tests, improving code health.

---
*PR created automatically by Jules for task [3839001616623207890](https://jules.google.com/task/3839001616623207890) started by @skurtyyskirts*