### PR TITLE
🧹 [code health improvement] Remove unused `_strip_known_texture_extensions` function

### DIFF
--- a/tests/test_remix_api.py
+++ b/tests/test_remix_api.py
@@ -8,11 +8,12 @@ from unittest.mock import patch, MagicMock
 # in environments where requests is not installed (e.g. minimal CI images).
 # remix_api treats requests as optional and guards all usage behind _get_session().
 _req_mock = MagicMock()
-_ConnErr = type("ConnectionError", (OSError,), {})
-_Timeout = type("Timeout", (OSError,), {})
+_ReqExc = type("RequestException", (OSError,), {})
+_ConnErr = type("ConnectionError", (_ReqExc,), {})
+_Timeout = type("Timeout", (_ReqExc,), {})
 _req_mock.exceptions.ConnectionError = _ConnErr
 _req_mock.exceptions.Timeout = _Timeout
-_req_mock.exceptions.RequestException = type("RequestException", (OSError,), {})
+_req_mock.exceptions.RequestException = _ReqExc
 sys.modules.setdefault("requests", _req_mock)
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))

--- a/tests/test_texture_processor.py
+++ b/tests/test_texture_processor.py
@@ -32,21 +32,6 @@ class TestSanitizeFilename(unittest.TestCase):
         self.assertEqual(_make_processor()._sanitize_filename_stem(""), "")
 
 
-class TestStripKnownTextureExtensions(unittest.TestCase):
-    def test_strips_dds(self):
-        self.assertEqual(TextureProcessor._strip_known_texture_extensions("foo.dds"), "foo")
-
-    def test_strips_rtex_dds(self):
-        self.assertEqual(TextureProcessor._strip_known_texture_extensions("foo.rtex.dds"), "foo")
-
-    def test_strips_png(self):
-        self.assertEqual(TextureProcessor._strip_known_texture_extensions("bar.png"), "bar")
-
-    def test_handles_windows_path(self):
-        result = TextureProcessor._strip_known_texture_extensions(r"C:\textures\foo.dds")
-        self.assertEqual(result, "foo")
-
-
 class TestStripIngestChannelSuffix(unittest.TestCase):
     def test_strips_single_letter_suffixes(self):
         for letter in "anrmheo":

--- a/texture_processor.py
+++ b/texture_processor.py
@@ -54,15 +54,6 @@ class TextureProcessor:
         return cleaned[:120]
 
     @staticmethod
-    def _strip_known_texture_extensions(texture_path_or_name):
-        if not texture_path_or_name: return ""
-        base = TextureProcessor.safe_basename(str(texture_path_or_name).replace("\\", "/"))
-        stem = os.path.splitext(base)[0]
-        if stem.lower().endswith(".rtex"):
-            stem = os.path.splitext(stem)[0]
-        return stem
-
-    @staticmethod
     def _strip_ingest_channel_suffix(stem):
         if not stem: return ""
         return re.sub(r"\.[armhnoaodse]$", "", str(stem), flags=re.IGNORECASE)


### PR DESCRIPTION
🎯 **What:** Removed the unused `_strip_known_texture_extensions` function from `texture_processor.py` and its corresponding tests. Also fixed the exceptions in `tests/test_remix_api.py` to ensure the mock exceptions match the `requests` library inheritance hierarchy.

💡 **Why:** `_strip_known_texture_extensions` is a small, self-contained unused function, making it dead code. Removing it clears clutter and improves the maintainability and readability of the codebase with zero risk.

✅ **Verification:**
1. Confirmed the function was not used anywhere in the codebase using `grep`.
2. Removed the corresponding unit tests for the function.
3. Fixed `ConnectionError` and `Timeout` mock exceptions in `tests/test_remix_api.py` to inherit from the mocked `RequestException`, allowing the full test suite to run via `python3 -m unittest discover tests`.
4. Verified that all 26 tests in the suite pass successfully.

✨ **Result:** A cleaner codebase with dead code removed, improving code health without changing behavior.

---
*PR created automatically by Jules for task [7076223507829850206](https://jules.google.com/task/7076223507829850206) started by @skurtyyskirts*