### PR TITLE
🧪 Add missing tests for _force_push_root_conflicts

### DIFF
--- a/tests/test_remix_api.py
+++ b/tests/test_remix_api.py
@@ -8,11 +8,12 @@ from unittest.mock import patch, MagicMock
 # in environments where requests is not installed (e.g. minimal CI images).
 # remix_api treats requests as optional and guards all usage behind _get_session().
 _req_mock = MagicMock()
-_ConnErr = type("ConnectionError", (OSError,), {})
-_Timeout = type("Timeout", (OSError,), {})
+_ReqExc = type("RequestException", (OSError,), {})
+_ConnErr = type("ConnectionError", (_ReqExc,), {})
+_Timeout = type("Timeout", (_ReqExc,), {})
+_req_mock.exceptions.RequestException = _ReqExc
 _req_mock.exceptions.ConnectionError = _ConnErr
 _req_mock.exceptions.Timeout = _Timeout
-_req_mock.exceptions.RequestException = type("RequestException", (OSError,), {})
 sys.modules.setdefault("requests", _req_mock)
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))

--- a/tests/test_texture_processor.py
+++ b/tests/test_texture_processor.py
@@ -153,5 +153,72 @@ class TestChooseNonOverwritingRoot(unittest.TestCase):
         self.assertEqual(result, "foo")
 
 
+
+
+class TestForcePushRootConflicts(unittest.TestCase):
+    def setUp(self):
+        self.tp = _make_processor()
+
+    @patch("os.path.isdir", return_value=True)
+    @patch("os.listdir")
+    def test_returns_false_for_invalid_inputs(self, mock_listdir, mock_isdir):
+        self.assertFalse(self.tp._force_push_root_conflicts("", "/fake/dir"))
+        self.assertFalse(self.tp._force_push_root_conflicts("root", ""))
+        self.assertFalse(self.tp._force_push_root_conflicts(None, "/fake/dir"))
+        self.assertFalse(self.tp._force_push_root_conflicts("root", None))
+
+        mock_isdir.return_value = False
+        self.assertFalse(self.tp._force_push_root_conflicts("root", "/fake/dir"))
+
+    @patch("os.path.isdir", return_value=True)
+    @patch("os.listdir")
+    def test_returns_false_if_listdir_fails(self, mock_listdir, mock_isdir):
+        mock_listdir.side_effect = PermissionError("Access denied")
+        self.assertFalse(self.tp._force_push_root_conflicts("root", "/fake/dir"))
+
+    @patch("os.path.isdir", return_value=True)
+    @patch("os.listdir")
+    def test_returns_false_for_unrelated_files(self, mock_listdir, mock_isdir):
+        mock_listdir.return_value = ["other.dds", "root.png", "root_model.obj", "completely_different.rtex.dds"]
+        self.assertFalse(self.tp._force_push_root_conflicts("root", "/fake/dir"))
+
+    @patch("os.path.isdir", return_value=True)
+    @patch("os.listdir")
+    def test_returns_false_for_prefix_but_no_separator(self, mock_listdir, mock_isdir):
+        # Starts with 'root' but the next char is not separator
+        mock_listdir.return_value = ["rootabc.dds", "root123.rtex.dds"]
+        self.assertFalse(self.tp._force_push_root_conflicts("root", "/fake/dir"))
+
+    @patch("os.path.isdir", return_value=True)
+    @patch("os.listdir")
+    def test_returns_true_for_exact_match(self, mock_listdir, mock_isdir):
+        mock_listdir.return_value = ["root.dds"]
+        self.assertTrue(self.tp._force_push_root_conflicts("root", "/fake/dir"))
+
+        mock_listdir.return_value = ["root.rtex.dds"]
+        self.assertTrue(self.tp._force_push_root_conflicts("root", "/fake/dir"))
+
+    @patch("os.path.isdir", return_value=True)
+    @patch("os.listdir")
+    def test_returns_true_for_separator_matches(self, mock_listdir, mock_isdir):
+        mock_listdir.return_value = ["root_1.dds"]
+        self.assertTrue(self.tp._force_push_root_conflicts("root", "/fake/dir"))
+
+        mock_listdir.return_value = ["root-albedo.rtex.dds"]
+        self.assertTrue(self.tp._force_push_root_conflicts("root", "/fake/dir"))
+
+        mock_listdir.return_value = ["root.normal.dds"]
+        self.assertTrue(self.tp._force_push_root_conflicts("root", "/fake/dir"))
+
+    @patch("os.path.isdir", return_value=True)
+    @patch("os.listdir")
+    def test_case_insensitive_matching(self, mock_listdir, mock_isdir):
+        mock_listdir.return_value = ["rOoT.DdS"]
+        self.assertTrue(self.tp._force_push_root_conflicts("ROOT", "/fake/dir"))
+
+        mock_listdir.return_value = ["ROOT_Albedo.rTeX.DdS"]
+        self.assertTrue(self.tp._force_push_root_conflicts("root", "/fake/dir"))
+
 if __name__ == "__main__":
+
     unittest.main()


### PR DESCRIPTION
🎯 **What:** The `_force_push_root_conflicts` method in `texture_processor.py` was missing test coverage, which handles the logic for detecting file naming conflicts when forcing texture pushes.

📊 **Coverage:**
- Falsy inputs and missing directories
- `os.listdir` exceptions (e.g. `PermissionError`)
- Unrelated files and varying extensions correctly ignored
- Valid separators (`.`, `_`, `-`, exact match) handled properly
- False-positive prefix matches explicitly rejected
- Case-insensitive matching logic verified for prefixes and extensions

✨ **Result:** Enhanced test coverage provides confidence in the conflict resolution logic of `TextureProcessor`. Also fixed a bug in test_remix_api.py that caused a couple failures when the requests library was mocked in the test suite.

---
*PR created automatically by Jules for task [15299886842303001694](https://jules.google.com/task/15299886842303001694) started by @skurtyyskirts*