### PR TITLE
🧪 Add tests for _force_push_root_conflicts in texture_processor.py

### DIFF
--- a/tests/test_texture_processor.py
+++ b/tests/test_texture_processor.py
@@ -155,3 +155,63 @@ class TestChooseNonOverwritingRoot(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+class TestForcePushRootConflicts(unittest.TestCase):
+    def setUp(self):
+        self.tp = _make_processor()
+
+    def test_invalid_args_returns_false(self):
+        self.assertFalse(self.tp._force_push_root_conflicts("", "/fake/dir"))
+        self.assertFalse(self.tp._force_push_root_conflicts(None, "/fake/dir"))
+        self.assertFalse(self.tp._force_push_root_conflicts("root", ""))
+        self.assertFalse(self.tp._force_push_root_conflicts("root", None))
+
+    @patch("os.path.isdir")
+    def test_missing_directory_returns_false(self, mock_isdir):
+        mock_isdir.return_value = False
+        self.assertFalse(self.tp._force_push_root_conflicts("root", "/fake/dir"))
+
+    @patch("os.path.isdir")
+    @patch("os.listdir")
+    def test_conflicting_names_return_true(self, mock_listdir, mock_isdir):
+        mock_isdir.return_value = True
+
+        # Exact match + extension
+        mock_listdir.return_value = ["mymat.dds"]
+        self.assertTrue(self.tp._force_push_root_conflicts("mymat", "/fake/dir"))
+
+        # Different case
+        mock_listdir.return_value = ["MYMAT.DDS"]
+        self.assertTrue(self.tp._force_push_root_conflicts("mymat", "/fake/dir"))
+
+        # Underscore suffix
+        mock_listdir.return_value = ["mymat_albedo.dds"]
+        self.assertTrue(self.tp._force_push_root_conflicts("mymat", "/fake/dir"))
+
+        # Hyphen suffix
+        mock_listdir.return_value = ["mymat-normal.rtex.dds"]
+        self.assertTrue(self.tp._force_push_root_conflicts("mymat", "/fake/dir"))
+
+    @patch("os.path.isdir")
+    @patch("os.listdir")
+    def test_non_conflicting_names_return_false(self, mock_listdir, mock_isdir):
+        mock_isdir.return_value = True
+
+        # Starts with root but not followed by delimiter
+        mock_listdir.return_value = ["mymatalbedo.dds"]
+        self.assertFalse(self.tp._force_push_root_conflicts("mymat", "/fake/dir"))
+
+        # Partial root match
+        mock_listdir.return_value = ["myma.dds"]
+        self.assertFalse(self.tp._force_push_root_conflicts("mymat", "/fake/dir"))
+
+        # Different extension
+        mock_listdir.return_value = ["mymat.png"]
+        self.assertFalse(self.tp._force_push_root_conflicts("mymat", "/fake/dir"))
+
+    @patch("os.path.isdir")
+    @patch("os.listdir")
+    def test_exception_during_listdir_returns_false(self, mock_listdir, mock_isdir):
+        mock_isdir.return_value = True
+        mock_listdir.side_effect = PermissionError("Access denied")
+        self.assertFalse(self.tp._force_push_root_conflicts("mymat", "/fake/dir"))


### PR DESCRIPTION
🎯 **What:** The `_force_push_root_conflicts` method in `texture_processor.py` was missing test coverage. This PR adds the missing tests by mocking `os.path.isdir` and `os.listdir` to simulate different directory states and filename combinations without doing actual file system I/O.

📊 **Coverage:** The new `TestForcePushRootConflicts` test suite covers the following scenarios:
  - Invalid arguments: Return `False` for empty string or `None`.
  - Non-existent directory: Return `False` if the directory does not exist.
  - Conflicting filenames: Return `True` for exact matches (+ extensions), case-insensitive matches, and names with underscore/hyphen suffixes.
  - Non-conflicting filenames: Return `False` for partial matches, names lacking a valid delimiter after the root string, and files with unrecognized extensions.
  - Error condition: Return `False` if an exception (e.g., `PermissionError`) occurs during `os.listdir()`.

✨ **Result:** The logic for resolving file naming conflicts is now thoroughly tested, improving test coverage and ensuring future modifications won't introduce regressions.

---
*PR created automatically by Jules for task [911562766899072909](https://jules.google.com/task/911562766899072909) started by @skurtyyskirts*