### PR TITLE
🧹 Remove unused sys import in remix_api.py

### DIFF
--- a/remix_api.py
+++ b/remix_api.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import json
 import time
 import urllib.parse

--- a/tests/test_remix_api.py
+++ b/tests/test_remix_api.py
@@ -8,11 +8,12 @@ from unittest.mock import patch, MagicMock
 # in environments where requests is not installed (e.g. minimal CI images).
 # remix_api treats requests as optional and guards all usage behind _get_session().
 _req_mock = MagicMock()
-_ConnErr = type("ConnectionError", (OSError,), {})
-_Timeout = type("Timeout", (OSError,), {})
+_ReqErr = type("RequestException", (OSError,), {})
+_ConnErr = type("ConnectionError", (_ReqErr,), {})
+_Timeout = type("Timeout", (_ReqErr,), {})
+_req_mock.exceptions.RequestException = _ReqErr
 _req_mock.exceptions.ConnectionError = _ConnErr
 _req_mock.exceptions.Timeout = _Timeout
-_req_mock.exceptions.RequestException = type("RequestException", (OSError,), {})
 sys.modules.setdefault("requests", _req_mock)
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))


### PR DESCRIPTION
🎯 **What:** The unused `import sys` statement in `remix_api.py` was removed.
💡 **Why:** To improve code health, reducing clutter and unused dependencies.
✅ **Verification:** Ran the full test suite (`python3 -m unittest discover tests`), fixed a preexisting testing issue related to mocked request exceptions, and made sure all tests passed.
✨ **Result:** A cleaner codebase with no unused dependencies.

---
*PR created automatically by Jules for task [10464393896611887063](https://jules.google.com/task/10464393896611887063) started by @skurtyyskirts*