### PR TITLE
🧹 Code Health: Remove unused `sys` import in `remix_api.py`

### DIFF
--- a/remix_api.py
+++ b/remix_api.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import json
 import time
 import urllib.parse

--- a/tests/test_remix_api.py
+++ b/tests/test_remix_api.py
@@ -8,11 +8,12 @@ from unittest.mock import patch, MagicMock
 # in environments where requests is not installed (e.g. minimal CI images).
 # remix_api treats requests as optional and guards all usage behind _get_session().
 _req_mock = MagicMock()
-_ConnErr = type("ConnectionError", (OSError,), {})
-_Timeout = type("Timeout", (OSError,), {})
+_ReqExc = type("RequestException", (OSError,), {})
+_req_mock.exceptions.RequestException = _ReqExc
+_ConnErr = type("ConnectionError", (_ReqExc,), {})
+_Timeout = type("Timeout", (_ReqExc,), {})
 _req_mock.exceptions.ConnectionError = _ConnErr
 _req_mock.exceptions.Timeout = _Timeout
-_req_mock.exceptions.RequestException = type("RequestException", (OSError,), {})
 sys.modules.setdefault("requests", _req_mock)
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))


### PR DESCRIPTION
🎯 **What:** The unused `sys` import in `remix_api.py` was removed. Furthermore, I fixed an issue where the test mock variables (`ConnectionError`, `Timeout`) were not properly inheriting from `RequestException` in `tests/test_remix_api.py`, which caused the retry logic to fail its assertions during testing.
💡 **Why:** Removing dead code makes the file easier to read and maintain. Fixing the unit tests guarantees the mock requests objects work properly during test runs, allowing retry logic assertions to pass successfully.
✅ **Verification:** Ran `python -m unittest discover tests` and `pytest tests/` to confirm that all 30 tests correctly pass with this configuration.
✨ **Result:** Clean code in `remix_api.py` and a fully passing test suite.

---
*PR created automatically by Jules for task [8286258098655970548](https://jules.google.com/task/8286258098655970548) started by @skurtyyskirts*