### PR TITLE
🧪 Add tests for TextureProcessor.safe_basename

### DIFF
--- a/tests/test_remix_api.py
+++ b/tests/test_remix_api.py
@@ -8,11 +8,12 @@ from unittest.mock import patch, MagicMock
 # in environments where requests is not installed (e.g. minimal CI images).
 # remix_api treats requests as optional and guards all usage behind _get_session().
 _req_mock = MagicMock()
-_ConnErr = type("ConnectionError", (OSError,), {})
-_Timeout = type("Timeout", (OSError,), {})
+_RequestException = type("RequestException", (OSError,), {})
+_ConnErr = type("ConnectionError", (_RequestException,), {})
+_Timeout = type("Timeout", (_RequestException,), {})
 _req_mock.exceptions.ConnectionError = _ConnErr
 _req_mock.exceptions.Timeout = _Timeout
-_req_mock.exceptions.RequestException = type("RequestException", (OSError,), {})
+_req_mock.exceptions.RequestException = _RequestException
 sys.modules.setdefault("requests", _req_mock)
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))

--- a/tests/test_texture_processor.py
+++ b/tests/test_texture_processor.py
@@ -153,5 +153,36 @@ class TestChooseNonOverwritingRoot(unittest.TestCase):
         self.assertEqual(result, "foo")
 
 
+
+class TestSafeBasename(unittest.TestCase):
+    def test_none_returns_empty_string(self):
+        self.assertEqual(TextureProcessor.safe_basename(None), "")
+
+    def test_empty_string_returns_empty_string(self):
+        self.assertEqual(TextureProcessor.safe_basename(""), "")
+
+    def test_forward_slashes(self):
+        self.assertEqual(TextureProcessor.safe_basename("some/path/file.dds"), "file.dds")
+
+    def test_backslashes(self):
+        self.assertEqual(TextureProcessor.safe_basename("some\\path\\file.dds"), "file.dds")
+
+    def test_mixed_slashes(self):
+        self.assertEqual(TextureProcessor.safe_basename("some/mixed\\path/file.dds"), "file.dds")
+
+    def test_no_slashes(self):
+        self.assertEqual(TextureProcessor.safe_basename("file.dds"), "file.dds")
+
+    def test_non_string_object(self):
+        import pathlib
+        path = pathlib.Path("some/path/file.dds")
+        self.assertEqual(TextureProcessor.safe_basename(path), "file.dds")
+
+    @patch("ntpath.basename")
+    def test_exception_fallback(self, mock_basename):
+        mock_basename.side_effect = Exception("Test exception")
+        self.assertEqual(TextureProcessor.safe_basename("some/path/file.dds"), "some/path/file.dds")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
- Missing edge case tests for `safe_basename` in `texture_processor.py`.

📊 **Coverage:** What scenarios are now tested
- `None` and empty strings (return empty strings)
- Standard forward slash paths
- Windows backslash paths
- Paths with mixed slashes
- Filenames with no slashes
- Non-string path objects like `pathlib.Path`
- Exception fallback if `ntpath.basename` fails

✨ **Result:** The improvement in test coverage
- Added the `TestSafeBasename` class, covering all branches and edge cases in the static method. Increased reliability for robust path processing.

---
*PR created automatically by Jules for task [8869999350118563890](https://jules.google.com/task/8869999350118563890) started by @skurtyyskirts*