### PR TITLE
🧪 Add tests for `ingest_texture` in Remix API

### DIFF
--- a/tests/test_remix_api.py
+++ b/tests/test_remix_api.py
@@ -8,11 +8,12 @@ from unittest.mock import patch, MagicMock
 # in environments where requests is not installed (e.g. minimal CI images).
 # remix_api treats requests as optional and guards all usage behind _get_session().
 _req_mock = MagicMock()
-_ConnErr = type("ConnectionError", (OSError,), {})
-_Timeout = type("Timeout", (OSError,), {})
+_RequestException = type("RequestException", (OSError,), {})
+_req_mock.exceptions.RequestException = _RequestException
+_ConnErr = type("ConnectionError", (_RequestException,), {})
+_Timeout = type("Timeout", (_RequestException,), {})
 _req_mock.exceptions.ConnectionError = _ConnErr
 _req_mock.exceptions.Timeout = _Timeout
-_req_mock.exceptions.RequestException = type("RequestException", (OSError,), {})
 sys.modules.setdefault("requests", _req_mock)
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
@@ -159,3 +160,230 @@ class TestPing(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+class TestIngestTexture(unittest.TestCase):
+    def setUp(self):
+        self.client = _make_client()
+
+    @patch("os.path.isfile")
+    def test_file_not_found(self, mock_isfile):
+        mock_isfile.return_value = False
+        res, err = self.client.ingest_texture("albedo", "/fake/path.png", "/out")
+        self.assertIsNone(res)
+        self.assertIn("File not found", err)
+
+    @patch("os.path.isfile")
+    @patch("os.makedirs")
+    def test_api_request_failed(self, mock_makedirs, mock_isfile):
+        mock_isfile.return_value = True
+
+        with patch.object(self.client, "make_request", return_value={"success": False, "error": "API Error"}):
+            res, err = self.client.ingest_texture("albedo", "/fake/path.png", "/out")
+
+        self.assertIsNone(res)
+        self.assertEqual(err, "API Error")
+
+    @patch("os.path.isfile")
+    @patch("os.makedirs")
+    def test_api_response_missing_path(self, mock_makedirs, mock_isfile):
+        mock_isfile.return_value = True
+
+        mock_response = {
+            "success": True,
+            "data": {
+                "completed_schemas": []
+            }
+        }
+
+        with patch.object(self.client, "make_request", return_value=mock_response):
+            res, err = self.client.ingest_texture("albedo", "/fake/path.png", "/out")
+
+        self.assertIsNone(res)
+        self.assertIn("Could not identify output path", err)
+
+    @patch("os.path.isfile")
+    @patch("os.makedirs")
+    def test_happy_path_with_expected_suffix(self, mock_makedirs, mock_isfile):
+        # We need isfile to be True for both the input file AND the output file check
+        mock_isfile.return_value = True
+
+        mock_response = {
+            "success": True,
+            "data": {
+                "content": ["path.a.rtex.dds", "path.n.rtex.dds"]
+            }
+        }
+
+        with patch.object(self.client, "make_request", return_value=mock_response):
+            res, err = self.client.ingest_texture("albedo", "/fake/path.png", "/out")
+
+        self.assertIsNotNone(res)
+        self.assertTrue(res.endswith("path.a.rtex.dds") or res.endswith(os.path.join("path.a.rtex.dds")))
+        self.assertIsNone(err)
+
+    @patch("os.path.isfile")
+    @patch("os.makedirs")
+    def test_fallback_match_when_suffix_missing(self, mock_makedirs, mock_isfile):
+        mock_isfile.return_value = True
+
+        mock_response = {
+            "success": True,
+            "data": {
+                "content": ["path.rtex.dds"]
+            }
+        }
+
+        with patch.object(self.client, "make_request", return_value=mock_response):
+            res, err = self.client.ingest_texture("albedo", "/fake/path.png", "/out")
+
+        self.assertIsNotNone(res)
+        self.assertTrue(res.endswith("path.rtex.dds"))
+        self.assertIsNone(err)
+
+    @patch("os.path.isfile")
+    @patch("os.makedirs")
+    def test_payload_construction(self, mock_makedirs, mock_isfile):
+        mock_isfile.return_value = True
+
+        # We need to capture the payload sent to make_request
+        mock_make_request = MagicMock(return_value={"success": False})
+
+        with patch.object(self.client, "make_request", new=mock_make_request):
+            self.client.ingest_texture("albedo", "/fake/path.png", "/out")
+
+        mock_make_request.assert_called_once()
+        args, kwargs = mock_make_request.call_args
+
+        self.assertEqual(args[0], "POST")
+        self.assertEqual(args[1], "/ingestcraft/mass-validator/queue/material")
+
+        payload = kwargs.get("json_payload")
+        self.assertIsNotNone(payload)
+
+        # Verify ingest_type was mapped correctly (albedo -> DIFFUSE)
+        input_files = payload["context_plugin"]["data"]["input_files"]
+        self.assertEqual(len(input_files), 1)
+        self.assertEqual(input_files[0][1], "DIFFUSE")
+
+
+    @patch("os.path.isfile")
+    @patch("os.makedirs")
+    def test_completed_schemas_parsing(self, mock_makedirs, mock_isfile):
+        mock_isfile.return_value = True
+
+        mock_response = {
+            "success": True,
+            "data": {
+                "completed_schemas": [
+                    {
+                        "context_plugin": {
+                            "data": {
+                                "data_flows": [
+                                    {
+                                        "channel": "ingestion_output",
+                                        "output_data": ["schema_path.a.rtex.dds"]
+                                    }
+                                ]
+                            }
+                        },
+                        "check_plugins": []
+                    }
+                ]
+            }
+        }
+
+        with patch.object(self.client, "make_request", return_value=mock_response):
+            res, err = self.client.ingest_texture("albedo", "/fake/schema_path.png", "/out")
+
+        self.assertIsNotNone(res)
+        self.assertTrue(res.endswith("schema_path.a.rtex.dds"))
+        self.assertIsNone(err)
+
+    @patch("os.path.isfile")
+    @patch("os.makedirs")
+    def test_non_matching_file_skipped(self, mock_makedirs, mock_isfile):
+        mock_isfile.return_value = True
+
+        mock_response = {
+            "success": True,
+            "data": {
+                "content": ["wrong_name.a.rtex.dds", 123, "right_name.png", "right_name.n.rtex.dds", "right_name.a.rtex.dds"]
+            }
+        }
+
+        with patch.object(self.client, "make_request", return_value=mock_response):
+            # should pick right_name.a.rtex.dds because pbr_type is albedo
+            res, err = self.client.ingest_texture("albedo", "/fake/right_name.png", "/out")
+
+        self.assertIsNotNone(res)
+        self.assertTrue(res.endswith("right_name.a.rtex.dds"))
+        self.assertIsNone(err)
+
+    @patch("os.path.isfile")
+    @patch("os.makedirs")
+    def test_missing_final_file(self, mock_makedirs, mock_isfile):
+        # isfile is true for input, but false for the final output path
+        mock_isfile.side_effect = [True, False]
+
+        mock_response = {
+            "success": True,
+            "data": {
+                "content": ["path.a.rtex.dds"]
+            }
+        }
+
+        with patch.object(self.client, "make_request", return_value=mock_response):
+            res, err = self.client.ingest_texture("albedo", "/fake/path.png", "/out")
+
+        self.assertIsNone(res)
+        self.assertIn("File missing:", err)
+
+    @patch("os.path.isfile")
+    @patch("os.makedirs")
+    def test_fallback_match_when_expected_suffix_not_present(self, mock_makedirs, mock_isfile):
+        mock_isfile.return_value = True
+
+        mock_response = {
+            "success": True,
+            "data": {
+                "content": ["path.z.rtex.dds"]
+            }
+        }
+
+        with patch.object(self.client, "make_request", return_value=mock_response):
+            res, err = self.client.ingest_texture("albedo", "/fake/path.png", "/out")
+
+        self.assertIsNotNone(res)
+        self.assertTrue(res.endswith("path.z.rtex.dds"))
+        self.assertIsNone(err)
+
+    @patch("os.path.isfile")
+    @patch("os.makedirs")
+    def test_no_expected_suffix(self, mock_makedirs, mock_isfile):
+        mock_isfile.return_value = True
+
+        mock_response = {
+            "success": True,
+            "data": {
+                "content": ["path.z.rtex.dds"]
+            }
+        }
+
+        with patch.object(self.client, "make_request", return_value=mock_response):
+            res, err = self.client.ingest_texture("unknown_type", "/fake/path.png", "/out")
+
+        self.assertIsNotNone(res)
+        self.assertTrue(res.endswith("path.z.rtex.dds"))
+        self.assertIsNone(err)
+
+
+    @patch("os.path.isfile")
+    @patch("os.makedirs")
+    def test_makedirs_exception(self, mock_makedirs, mock_isfile):
+        mock_isfile.return_value = True
+        mock_makedirs.side_effect = Exception("Permission denied")
+
+        res, err = self.client.ingest_texture("albedo", "/fake/path.png", "/out")
+
+        self.assertIsNone(res)
+        self.assertIn("Failed to create directory", err)


### PR DESCRIPTION
🎯 **What:** Added tests for the previously untested `ingest_texture` method in `RemixAPIClient` within `remix_api.py`.
📊 **Coverage:** The new test suite covers happy path filename matching (both expected suffix and fallback matches), error cases for file not found, failed directory creation, missing output files in API responses, and verifies payload construction (correctly mapping PBR types to Remix validation types). `requests` Mocking was also fixed to support RequestException correctly.
✨ **Result:** Test coverage for `remix_api.py` significantly improved, and confidence in the safety of `ingest_texture` changes increased.

---
*PR created automatically by Jules for task [1163918137528788038](https://jules.google.com/task/1163918137528788038) started by @skurtyyskirts*