### PR TITLE
🧹 Remove unused create_project method in painter_controller.py

### DIFF
--- a/painter_controller.py
+++ b/painter_controller.py
@@ -120,12 +120,3 @@ class PainterController:
         if hasattr(substance_painter.project, 'close'):
             substance_painter.project.close()
 
-    def create_project(self, mesh_file_path, template_path=None, project_settings=None):
-        if hasattr(substance_painter.project, 'create'):
-             # This signature depends on API version, keeping it simple or passing args
-             # The original code likely calls it directly. 
-             # For now, I'll let the main logic call substance_painter directly for complex ops 
-             # unless I wrap them fully.
-             pass
-        pass
-

--- a/tests/test_remix_api.py
+++ b/tests/test_remix_api.py
@@ -8,11 +8,12 @@ from unittest.mock import patch, MagicMock
 # in environments where requests is not installed (e.g. minimal CI images).
 # remix_api treats requests as optional and guards all usage behind _get_session().
 _req_mock = MagicMock()
-_ConnErr = type("ConnectionError", (OSError,), {})
-_Timeout = type("Timeout", (OSError,), {})
+_ReqErr = type("RequestException", (OSError,), {})
+_ConnErr = type("ConnectionError", (_ReqErr,), {})
+_Timeout = type("Timeout", (_ReqErr,), {})
 _req_mock.exceptions.ConnectionError = _ConnErr
 _req_mock.exceptions.Timeout = _Timeout
-_req_mock.exceptions.RequestException = type("RequestException", (OSError,), {})
+_req_mock.exceptions.RequestException = _ReqErr
 sys.modules.setdefault("requests", _req_mock)
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))


### PR DESCRIPTION
🎯 **What:** Removed the empty and unimplemented `create_project` method from `painter_controller.py`. Also fixed an issue in `tests/test_remix_api.py` regarding mocked Request exceptions.
💡 **Why:** The `create_project` method in `painter_controller.py` was unused placeholder code. `core.py` interacts directly with `substance_painter.project.create()`, making this method redundant and confusing. Removing it improves codebase maintainability.
✅ **Verification:** Ran `python3 -m unittest discover tests` successfully.
✨ **Result:** A cleaner `painter_controller.py` file with no dead code.

---
*PR created automatically by Jules for task [18437808402366231333](https://jules.google.com/task/18437808402366231333) started by @skurtyyskirts*