### PR TITLE
🧹 Remove unused `_strip_ingest_channel_suffix` method

### DIFF
--- a/tests/test_texture_processor.py
+++ b/tests/test_texture_processor.py
@@ -47,22 +47,6 @@ class TestStripKnownTextureExtensions(unittest.TestCase):
         self.assertEqual(result, "foo")
 
 
-class TestStripIngestChannelSuffix(unittest.TestCase):
-    def test_strips_single_letter_suffixes(self):
-        for letter in "anrmheo":
-            self.assertEqual(
-                TextureProcessor._strip_ingest_channel_suffix(f"foo.{letter}"),
-                "foo",
-                msg=f"expected suffix .{letter} to be stripped",
-            )
-
-    def test_leaves_no_suffix(self):
-        self.assertEqual(TextureProcessor._strip_ingest_channel_suffix("foo"), "foo")
-
-    def test_leaves_multi_char_suffix(self):
-        self.assertEqual(TextureProcessor._strip_ingest_channel_suffix("foo.ab"), "foo.ab")
-
-
 class TestConvertDdsToPng(unittest.TestCase):
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()

--- a/texture_processor.py
+++ b/texture_processor.py
@@ -62,11 +62,6 @@ class TextureProcessor:
             stem = os.path.splitext(stem)[0]
         return stem
 
-    @staticmethod
-    def _strip_ingest_channel_suffix(stem):
-        if not stem: return ""
-        return re.sub(r"\.[armhnoaodse]$", "", str(stem), flags=re.IGNORECASE)
-
     def convert_dds_to_png(self, texconv_exe, dds_file, output_png_target_name_base, output_dir_override=None):
         if not texconv_exe or not os.path.isfile(texconv_exe): 
             raise RuntimeError(f"texconv.exe path is not configured or invalid: {texconv_exe}")


### PR DESCRIPTION
🎯 What: Removed the unused `_strip_ingest_channel_suffix` method from `texture_processor.py` and its associated tests.
💡 Why: Improves code clarity and maintainability by removing dead code.
✅ Verification: Ran the test suite to ensure no existing functionality is broken.
✨ Result: Cleaner, more maintainable code without changing behavior.

---
*PR created automatically by Jules for task [12702371586720540827](https://jules.google.com/task/12702371586720540827) started by @skurtyyskirts*