### PR TITLE
🧹 [Code Health] Remove unused _strip_ingest_channel_suffix method

### DIFF
--- a/tests/test_texture_processor.py
+++ b/tests/test_texture_processor.py
@@ -47,20 +47,6 @@ class TestStripKnownTextureExtensions(unittest.TestCase):
         self.assertEqual(result, "foo")
 
 
-class TestStripIngestChannelSuffix(unittest.TestCase):
-    def test_strips_single_letter_suffixes(self):
-        for letter in "anrmheo":
-            self.assertEqual(
-                TextureProcessor._strip_ingest_channel_suffix(f"foo.{letter}"),
-                "foo",
-                msg=f"expected suffix .{letter} to be stripped",
-            )
-
-    def test_leaves_no_suffix(self):
-        self.assertEqual(TextureProcessor._strip_ingest_channel_suffix("foo"), "foo")
-
-    def test_leaves_multi_char_suffix(self):
-        self.assertEqual(TextureProcessor._strip_ingest_channel_suffix("foo.ab"), "foo.ab")
 
 
 class TestConvertDdsToPng(unittest.TestCase):

--- a/texture_processor.py
+++ b/texture_processor.py
@@ -62,11 +62,6 @@ class TextureProcessor:
             stem = os.path.splitext(stem)[0]
         return stem
 
-    @staticmethod
-    def _strip_ingest_channel_suffix(stem):
-        if not stem: return ""
-        return re.sub(r"\.[armhnoaodse]$", "", str(stem), flags=re.IGNORECASE)
-
     def convert_dds_to_png(self, texconv_exe, dds_file, output_png_target_name_base, output_dir_override=None):
         if not texconv_exe or not os.path.isfile(texconv_exe): 
             raise RuntimeError(f"texconv.exe path is not configured or invalid: {texconv_exe}")


### PR DESCRIPTION
🎯 **What:** The `_strip_ingest_channel_suffix` static method was completely unused throughout the project. It and its corresponding test class (`TestStripIngestChannelSuffix` in `tests/test_texture_processor.py`) have been removed.

💡 **Why:** Removing dead code shrinks the codebase, reduces mental overhead for maintainers, and improves readability with absolutely zero behavioral side effects.

✅ **Verification:** Verified by inspecting usages in the source files, patching `texture_processor.py`, and executing the relevant tests in `tests/test_texture_processor.py` to ensure successful completion. (Note: Unrelated pre-existing errors in `test_remix_api.py` were left untouched to maintain tight scope.)

✨ **Result:** A leaner codebase that is slightly easier to maintain.

---
*PR created automatically by Jules for task [439347117239589404](https://jules.google.com/task/439347117239589404) started by @skurtyyskirts*