### PR TITLE
🧹 [Code Health] Remove unused `sys` import in `remix_api.py`

### DIFF
--- a/remix_api.py
+++ b/remix_api.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import json
 import time
 import urllib.parse

--- a/tests/test_remix_api.py
+++ b/tests/test_remix_api.py
@@ -8,11 +8,12 @@ from unittest.mock import patch, MagicMock
 # in environments where requests is not installed (e.g. minimal CI images).
 # remix_api treats requests as optional and guards all usage behind _get_session().
 _req_mock = MagicMock()
-_ConnErr = type("ConnectionError", (OSError,), {})
-_Timeout = type("Timeout", (OSError,), {})
+_RequestException = type("RequestException", (OSError,), {})
+_ConnErr = type("ConnectionError", (_RequestException,), {})
+_Timeout = type("Timeout", (_RequestException,), {})
+_req_mock.exceptions.RequestException = _RequestException
 _req_mock.exceptions.ConnectionError = _ConnErr
 _req_mock.exceptions.Timeout = _Timeout
-_req_mock.exceptions.RequestException = type("RequestException", (OSError,), {})
 sys.modules.setdefault("requests", _req_mock)
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))


### PR DESCRIPTION
🎯 **What:** Removed unused `sys` import from `remix_api.py`. Fixed the `tests/test_remix_api.py` mock of the `requests` library to make the `ConnectionError` and `Timeout` mock exceptions inherit from the mocked `RequestException`.
💡 **Why:** Having unused imports decreases code clarity and maintainability. The test mock update aligns with memory requirements to ensure the internal retry logic correctly handles these exceptions.
✅ **Verification:** Verified by ensuring the test suite ran successfully and no other files referenced the `sys` import. Checked `tests/test_remix_api.py` functionality. 
✨ **Result:** A cleaner `remix_api.py` with improved health and an updated test configuration.

---
*PR created automatically by Jules for task [3056350611576570097](https://jules.google.com/task/3056350611576570097) started by @skurtyyskirts*