### PR TITLE
🧪 Add tests for get_material_from_mesh

### DIFF
--- a/tests/test_remix_api.py
+++ b/tests/test_remix_api.py
@@ -8,11 +8,12 @@ from unittest.mock import patch, MagicMock
 # in environments where requests is not installed (e.g. minimal CI images).
 # remix_api treats requests as optional and guards all usage behind _get_session().
 _req_mock = MagicMock()
-_ConnErr = type("ConnectionError", (OSError,), {})
-_Timeout = type("Timeout", (OSError,), {})
+_RequestException = type("RequestException", (OSError,), {})
+_ConnErr = type("ConnectionError", (_RequestException,), {})
+_Timeout = type("Timeout", (_RequestException,), {})
+_req_mock.exceptions.RequestException = _RequestException
 _req_mock.exceptions.ConnectionError = _ConnErr
 _req_mock.exceptions.Timeout = _Timeout
-_req_mock.exceptions.RequestException = type("RequestException", (OSError,), {})
 sys.modules.setdefault("requests", _req_mock)
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
@@ -159,3 +160,53 @@ class TestPing(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+class TestGetMaterialFromMesh(unittest.TestCase):
+    def test_empty_path(self):
+        client = _make_client()
+        result = client.get_material_from_mesh("")
+        self.assertEqual(result, (None, "Mesh prim path cannot be empty."))
+
+        result = client.get_material_from_mesh(None)
+        self.assertEqual(result, (None, "Mesh prim path cannot be empty."))
+
+    @patch.object(RemixAPIClient, "make_request")
+    def test_success(self, mock_make_request):
+        client = _make_client()
+        mock_make_request.return_value = {
+            "success": True,
+            "data": {"asset_path": r"C:\material\path"}
+        }
+
+        result = client.get_material_from_mesh("/mesh/path")
+        self.assertEqual(result, ("C:/material/path", None))
+
+    @patch.object(RemixAPIClient, "make_request")
+    def test_api_failure(self, mock_make_request):
+        client = _make_client()
+        mock_make_request.return_value = {
+            "success": False,
+            "error": "Some error"
+        }
+
+        result = client.get_material_from_mesh("/mesh/path")
+        self.assertEqual(result, (None, "Some error"))
+
+    @patch.object(RemixAPIClient, "make_request")
+    def test_no_asset_path_in_data(self, mock_make_request):
+        client = _make_client()
+        mock_make_request.return_value = {
+            "success": True,
+            "data": {}
+        }
+
+        result = client.get_material_from_mesh("/mesh/path")
+        self.assertEqual(result, (None, "Failed to query bound material."))
+
+    @patch.object(RemixAPIClient, "make_request")
+    def test_exception_handling(self, mock_make_request):
+        client = _make_client()
+        mock_make_request.side_effect = Exception("Some runtime error")
+
+        result = client.get_material_from_mesh("/mesh/path")
+        self.assertEqual(result, (None, "Some runtime error"))


### PR DESCRIPTION
🎯 **What:** This adds missing unit tests for `get_material_from_mesh` in `remix_api.py`.
📊 **Coverage:** The tests now cover cases for missing/empty input paths, successful parsing of the material paths from the JSON response, mock request failures, empty JSON structure parsing, and exception scenarios.
✨ **Result:** Test coverage for `remix_api.py` has been significantly increased and handles both expected responses and failure cases robustly.

---
*PR created automatically by Jules for task [11288021668190642042](https://jules.google.com/task/11288021668190642042) started by @skurtyyskirts*