### PR TITLE
🔒 Fix arbitrary code execution vulnerability in subprocess execution

### DIFF
--- a/settings_schema.py
+++ b/settings_schema.py
@@ -154,6 +154,13 @@ def atomic_write_json(path: str, data: Dict[str, Any]) -> Tuple[bool, str]:
         tmp_path = f"{path}.tmp"
         with open(tmp_path, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=4)
+
+        # Set file permissions to 0o600 for security
+        try:
+            os.chmod(tmp_path, 0o600)
+        except Exception:
+            pass
+
         os.replace(tmp_path, path)
         return True, ""
     except Exception as e:

--- a/tests/test_remix_api.py
+++ b/tests/test_remix_api.py
@@ -8,11 +8,12 @@ from unittest.mock import patch, MagicMock
 # in environments where requests is not installed (e.g. minimal CI images).
 # remix_api treats requests as optional and guards all usage behind _get_session().
 _req_mock = MagicMock()
-_ConnErr = type("ConnectionError", (OSError,), {})
-_Timeout = type("Timeout", (OSError,), {})
+_ReqExc = type("RequestException", (OSError,), {})
+_ConnErr = type("ConnectionError", (_ReqExc,), {})
+_Timeout = type("Timeout", (_ReqExc,), {})
 _req_mock.exceptions.ConnectionError = _ConnErr
 _req_mock.exceptions.Timeout = _Timeout
-_req_mock.exceptions.RequestException = type("RequestException", (OSError,), {})
+_req_mock.exceptions.RequestException = _ReqExc
 sys.modules.setdefault("requests", _req_mock)
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))

--- a/tests/test_texture_processor.py
+++ b/tests/test_texture_processor.py
@@ -83,6 +83,14 @@ class TestConvertDdsToPng(unittest.TestCase):
             self.tp.convert_dds_to_png(fake_texconv, "/nonexistent/foo.dds", "foo")
         self.assertIn("not found", str(ctx.exception))
 
+    def test_raises_if_executable_name_invalid(self):
+        fake_texconv = os.path.join(self.tmpdir, "malicious.exe")
+        open(fake_texconv, "w").close()
+        with self.assertRaises(RuntimeError) as ctx:
+            self.tp.convert_dds_to_png(fake_texconv, "/nonexistent/foo.dds", "foo")
+        self.assertIn("Security error", str(ctx.exception))
+        self.assertIn("Invalid executable name", str(ctx.exception))
+
     @patch("subprocess.run")
     def test_raises_on_nonzero_returncode(self, mock_run):
         fake_texconv = os.path.join(self.tmpdir, "texconv.exe")

--- a/texture_processor.py
+++ b/texture_processor.py
@@ -70,6 +70,11 @@ class TextureProcessor:
     def convert_dds_to_png(self, texconv_exe, dds_file, output_png_target_name_base, output_dir_override=None):
         if not texconv_exe or not os.path.isfile(texconv_exe): 
             raise RuntimeError(f"texconv.exe path is not configured or invalid: {texconv_exe}")
+
+        exe_name = os.path.basename(texconv_exe).lower()
+        if exe_name not in ("texconv", "texconv.exe"):
+            raise RuntimeError(f"Security error: Invalid executable name '{exe_name}'. Expected 'texconv' or 'texconv.exe'.")
+
         if not os.path.isfile(dds_file): 
             raise RuntimeError(f"Input DDS file not found: {dds_file}")
 
@@ -146,6 +151,14 @@ class TextureProcessor:
             self._log_error(f"Blender executable invalid: '{blender_exe}'")
             self._display_message("Error: Blender executable path invalid.")
             return None
+
+        exe_name = os.path.basename(blender_exe).lower()
+        if exe_name not in ("blender", "blender.exe"):
+            err_msg = f"Security error: Invalid executable name '{exe_name}'. Expected 'blender' or 'blender.exe'."
+            self._log_error(err_msg)
+            self._display_message(f"Error: {err_msg}")
+            return None
+
         if not unwrap_script_path:
             self._display_message("Error: Blender unwrap script not found.")
             return None


### PR DESCRIPTION
🎯 What:
- Added executable name validation in `texture_processor.py` for `texconv_exe` and `blender_exe` paths.
- Enforced `0o600` permissions on the `settings.json` file created by `settings_schema.py`.
- Fixed test suites inheriting properly from `RequestException` for `ConnectionError` and `Timeout` mocks.

⚠️ Risk:
A malicious user or process could modify the `settings.json` file to point `texconv_path` or `blender_executable_path` to an arbitrary executable (e.g. cmd.exe, malicious.exe). This would lead to arbitrary code execution when the script passes these strings directly into `subprocess.run()`.

🛡️ Solution:
- Validated that `os.path.basename` matches expected executable names.
- Created `settings.json` files with strict `0o600` owner-only read/write permissions to limit unauthorized modifications.
- Added tests to enforce the valid executable check.

---
*PR created automatically by Jules for task [1777185244544561292](https://jules.google.com/task/1777185244544561292) started by @skurtyyskirts*