### PR TITLE
🔒 Fix arbitrary code execution vulnerability in subprocess invocations

### DIFF
--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,0 +1,12 @@
+🔒 Fix arbitrary code execution vulnerability in subprocess invocations
+
+🎯 What:
+The plugin executes `texconv.exe` and `blender` as subprocesses using paths configured in the settings file. A malicious actor modifying `settings.json` could point these executables to arbitrary binaries (e.g., `cmd.exe` or `powershell.exe`) resulting in arbitrary code execution when the user attempts a sync operation.
+
+⚠️ Risk:
+A malicious user modifying the settings file could achieve arbitrary code execution via the vulnerable subprocess calls in `convert_dds_to_png` and `unwrap_mesh_with_blender`. This poses a significant security threat.
+
+🛡️ Solution:
+Added security validations to check the executable basename against a predefined list of allowed binaries (`texconv`, `texconv.exe`) or prefixes (`blender`). If an invalid executable is specified, a runtime error is raised or execution is halted safely.
+
+The `safe_basename` method has also been correctly utilized and test mocks have been updated.

--- a/tests/test_remix_api.py
+++ b/tests/test_remix_api.py
@@ -8,11 +8,12 @@ from unittest.mock import patch, MagicMock
 # in environments where requests is not installed (e.g. minimal CI images).
 # remix_api treats requests as optional and guards all usage behind _get_session().
 _req_mock = MagicMock()
-_ConnErr = type("ConnectionError", (OSError,), {})
-_Timeout = type("Timeout", (OSError,), {})
+_ReqErr = type("RequestException", (OSError,), {})
+_req_mock.exceptions.RequestException = _ReqErr
+_ConnErr = type("ConnectionError", (_ReqErr,), {})
+_Timeout = type("Timeout", (_ReqErr,), {})
 _req_mock.exceptions.ConnectionError = _ConnErr
 _req_mock.exceptions.Timeout = _Timeout
-_req_mock.exceptions.RequestException = type("RequestException", (OSError,), {})
 sys.modules.setdefault("requests", _req_mock)
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))

--- a/tests/test_texture_processor.py
+++ b/tests/test_texture_processor.py
@@ -83,6 +83,15 @@ class TestConvertDdsToPng(unittest.TestCase):
             self.tp.convert_dds_to_png(fake_texconv, "/nonexistent/foo.dds", "foo")
         self.assertIn("not found", str(ctx.exception))
 
+    def test_raises_on_invalid_texconv_executable_name(self):
+        fake_texconv = os.path.join(self.tmpdir, "cmd.exe")
+        open(fake_texconv, "w").close()
+        fake_dds = os.path.join(self.tmpdir, "foo.dds")
+        open(fake_dds, "w").close()
+        with self.assertRaises(RuntimeError) as ctx:
+            self.tp.convert_dds_to_png(fake_texconv, fake_dds, "foo")
+        self.assertIn("Security validation failed", str(ctx.exception))
+
     @patch("subprocess.run")
     def test_raises_on_nonzero_returncode(self, mock_run):
         fake_texconv = os.path.join(self.tmpdir, "texconv.exe")
@@ -155,3 +164,26 @@ class TestChooseNonOverwritingRoot(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+class TestUnwrapMeshWithBlender(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_rejects_invalid_blender_executable_name(self):
+        fake_blender = os.path.join(self.tmpdir, "powershell.exe")
+        open(fake_blender, "w").close()
+        fake_mesh = os.path.join(self.tmpdir, "mesh.obj")
+
+        settings = {
+            "blender_executable_path": fake_blender,
+            "blender_unwrap_script_path": os.path.join(self.tmpdir, "script.py")
+        }
+        tp = _make_processor(settings)
+
+        result = tp.unwrap_mesh_with_blender(fake_mesh)
+        self.assertIsNone(result)
+        # Should have logged error
+        tp.logger.error.assert_called_with("Security validation failed: Invalid Blender executable name 'powershell.exe'.", exc_info=False)

--- a/texture_processor.py
+++ b/texture_processor.py
@@ -73,6 +73,11 @@ class TextureProcessor:
         if not os.path.isfile(dds_file): 
             raise RuntimeError(f"Input DDS file not found: {dds_file}")
 
+        # Security validation to prevent arbitrary code execution from modified settings
+        exe_name = self.safe_basename(texconv_exe).lower()
+        if exe_name not in ("texconv.exe", "texconv"):
+            raise RuntimeError(f"Security validation failed: Invalid executable name '{exe_name}'. Must be texconv.")
+
         output_dir = output_dir_override if output_dir_override else os.path.dirname(dds_file)
         os.makedirs(output_dir, exist_ok=True)
 
@@ -148,6 +153,13 @@ class TextureProcessor:
             return None
         if not unwrap_script_path:
             self._display_message("Error: Blender unwrap script not found.")
+            return None
+
+        # Security validation to prevent arbitrary code execution from modified settings
+        exe_name = self.safe_basename(blender_exe).lower()
+        if not exe_name.startswith("blender"):
+            self._log_error(f"Security validation failed: Invalid Blender executable name '{exe_name}'.")
+            self._display_message("Error: Security validation failed for Blender path.")
             return None
 
         base, ext = os.path.splitext(input_mesh_path)


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
The plugin executes `texconv.exe` and `blender` as subprocesses using paths configured in the settings file. A malicious actor modifying `settings.json` could point these executables to arbitrary binaries (e.g., `cmd.exe` or `powershell.exe`) resulting in arbitrary code execution when the user attempts a sync operation.

⚠️ **Risk:** The potential impact if left unfixed
A malicious user modifying the settings file could achieve arbitrary code execution via the vulnerable subprocess calls in `convert_dds_to_png` and `unwrap_mesh_with_blender`. This poses a significant security threat.

🛡️ **Solution:** How the fix addresses the vulnerability
Added security validations to check the executable basename against a predefined list of allowed binaries (`texconv`, `texconv.exe`) or prefixes (`blender`). If an invalid executable is specified, a runtime error is raised or execution is halted safely.

The `safe_basename` method has also been correctly utilized and test mocks have been updated.

---
*PR created automatically by Jules for task [1176813054728385586](https://jules.google.com/task/1176813054728385586) started by @skurtyyskirts*