### PR TITLE
🧹 Remove unused `_strip_known_texture_extensions`

### DIFF
--- a/tests/test_remix_api.py
+++ b/tests/test_remix_api.py
@@ -8,11 +8,15 @@ from unittest.mock import patch, MagicMock
 # in environments where requests is not installed (e.g. minimal CI images).
 # remix_api treats requests as optional and guards all usage behind _get_session().
 _req_mock = MagicMock()
-_ConnErr = type("ConnectionError", (OSError,), {})
-_Timeout = type("Timeout", (OSError,), {})
+class RequestException(OSError): pass
+_req_mock.exceptions.RequestException = RequestException
+class ConnectionError(RequestException): pass
+_ConnErr = ConnectionError
+class Timeout(RequestException): pass
+_Timeout = Timeout
 _req_mock.exceptions.ConnectionError = _ConnErr
 _req_mock.exceptions.Timeout = _Timeout
-_req_mock.exceptions.RequestException = type("RequestException", (OSError,), {})
+
 sys.modules.setdefault("requests", _req_mock)
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))

--- a/tests/test_texture_processor.py
+++ b/tests/test_texture_processor.py
@@ -32,21 +32,6 @@ class TestSanitizeFilename(unittest.TestCase):
         self.assertEqual(_make_processor()._sanitize_filename_stem(""), "")
 
 
-class TestStripKnownTextureExtensions(unittest.TestCase):
-    def test_strips_dds(self):
-        self.assertEqual(TextureProcessor._strip_known_texture_extensions("foo.dds"), "foo")
-
-    def test_strips_rtex_dds(self):
-        self.assertEqual(TextureProcessor._strip_known_texture_extensions("foo.rtex.dds"), "foo")
-
-    def test_strips_png(self):
-        self.assertEqual(TextureProcessor._strip_known_texture_extensions("bar.png"), "bar")
-
-    def test_handles_windows_path(self):
-        result = TextureProcessor._strip_known_texture_extensions(r"C:\textures\foo.dds")
-        self.assertEqual(result, "foo")
-
-
 class TestStripIngestChannelSuffix(unittest.TestCase):
     def test_strips_single_letter_suffixes(self):
         for letter in "anrmheo":

--- a/texture_processor.py
+++ b/texture_processor.py
@@ -53,14 +53,6 @@ class TextureProcessor:
         cleaned = cleaned.strip(" .")
         return cleaned[:120]
 
-    @staticmethod
-    def _strip_known_texture_extensions(texture_path_or_name):
-        if not texture_path_or_name: return ""
-        base = TextureProcessor.safe_basename(str(texture_path_or_name).replace("\\", "/"))
-        stem = os.path.splitext(base)[0]
-        if stem.lower().endswith(".rtex"):
-            stem = os.path.splitext(stem)[0]
-        return stem
 
     @staticmethod
     def _strip_ingest_channel_suffix(stem):


### PR DESCRIPTION
🎯 **What:** Removed the unused `_strip_known_texture_extensions` static method from `texture_processor.py`, along with its associated unit tests in `tests/test_texture_processor.py`. Also fixed the test suite mock exception inheritance for requests in `tests/test_remix_api.py` to pass tests successfully.
💡 **Why:** To eliminate dead code and improve code health/maintainability.
✅ **Verification:** Ran `pytest` and `python3 -m unittest discover tests` to ensure the test suite is fully green and no functionality broke.
✨ **Result:** A cleaner `texture_processor.py` and test suite without untested or dead code, and standardizing requests mock exceptions.

---
*PR created automatically by Jules for task [9765888511104902227](https://jules.google.com/task/9765888511104902227) started by @skurtyyskirts*