### PR TITLE
🔒 Fix subprocess execution using externally configured path

### DIFF
--- a/tests/test_remix_api.py
+++ b/tests/test_remix_api.py
@@ -8,11 +8,14 @@ from unittest.mock import patch, MagicMock
 # in environments where requests is not installed (e.g. minimal CI images).
 # remix_api treats requests as optional and guards all usage behind _get_session().
 _req_mock = MagicMock()
-_ConnErr = type("ConnectionError", (OSError,), {})
-_Timeout = type("Timeout", (OSError,), {})
+
+_ReqExc = type("RequestException", (OSError,), {})
+_ConnErr = type("ConnectionError", (_ReqExc,), {})
+_Timeout = type("Timeout", (_ReqExc,), {})
 _req_mock.exceptions.ConnectionError = _ConnErr
 _req_mock.exceptions.Timeout = _Timeout
-_req_mock.exceptions.RequestException = type("RequestException", (OSError,), {})
+_req_mock.exceptions.RequestException = _ReqExc
+
 sys.modules.setdefault("requests", _req_mock)
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))

--- a/tests/test_texture_processor.py
+++ b/tests/test_texture_processor.py
@@ -76,6 +76,13 @@ class TestConvertDdsToPng(unittest.TestCase):
             self.tp.convert_dds_to_png("/nonexistent/texconv.exe", "/some/file.dds", "output")
         self.assertIn("texconv.exe", str(ctx.exception))
 
+    def test_raises_if_texconv_has_invalid_name(self):
+        fake_texconv = os.path.join(self.tmpdir, "malicious.exe")
+        open(fake_texconv, "w").close()
+        with self.assertRaises(RuntimeError) as ctx:
+            self.tp.convert_dds_to_png(fake_texconv, "/some/file.dds", "output")
+        self.assertIn("Security error: Invalid executable name", str(ctx.exception))
+
     def test_raises_if_dds_missing(self):
         fake_texconv = os.path.join(self.tmpdir, "texconv.exe")
         open(fake_texconv, "w").close()
@@ -130,6 +137,44 @@ class TestConvertDdsToPng(unittest.TestCase):
         result = self.tp.convert_dds_to_png(fake_texconv, fake_dds, "foo")
         self.assertEqual(result, expected_png)
 
+
+
+class TestUnwrapMeshWithBlender(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.tp = _make_processor({
+            "blender_executable_path": os.path.join(self.tmpdir, "blender.exe"),
+            "blender_unwrap_script_path": os.path.join(self.tmpdir, "unwrap.py")
+        })
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_returns_none_if_blender_has_invalid_name(self):
+        fake_blender = os.path.join(self.tmpdir, "malicious.exe")
+        open(fake_blender, "w").close()
+        self.tp.settings_getter = lambda: {
+            "blender_executable_path": fake_blender,
+            "blender_unwrap_script_path": os.path.join(self.tmpdir, "unwrap.py")
+        }
+
+        result = self.tp.unwrap_mesh_with_blender("/some/mesh.obj")
+        self.assertIsNone(result)
+
+    def test_returns_none_if_unwrap_script_has_invalid_extension(self):
+        fake_blender = os.path.join(self.tmpdir, "blender.exe")
+        open(fake_blender, "w").close()
+
+        fake_script = os.path.join(self.tmpdir, "unwrap.bat")
+        open(fake_script, "w").close()
+
+        self.tp.settings_getter = lambda: {
+            "blender_executable_path": fake_blender,
+            "blender_unwrap_script_path": fake_script
+        }
+
+        result = self.tp.unwrap_mesh_with_blender("/some/mesh.obj")
+        self.assertIsNone(result)
 
 class TestChooseNonOverwritingRoot(unittest.TestCase):
     def setUp(self):

--- a/texture_processor.py
+++ b/texture_processor.py
@@ -70,6 +70,12 @@ class TextureProcessor:
     def convert_dds_to_png(self, texconv_exe, dds_file, output_png_target_name_base, output_dir_override=None):
         if not texconv_exe or not os.path.isfile(texconv_exe): 
             raise RuntimeError(f"texconv.exe path is not configured or invalid: {texconv_exe}")
+
+        # Security check: Ensure the executable is actually texconv
+        texconv_basename = self.safe_basename(texconv_exe).lower()
+        if texconv_basename not in ("texconv", "texconv.exe"):
+            raise RuntimeError(f"Security error: Invalid executable name '{texconv_basename}' for texconv.")
+
         if not os.path.isfile(dds_file): 
             raise RuntimeError(f"Input DDS file not found: {dds_file}")
 
@@ -146,9 +152,24 @@ class TextureProcessor:
             self._log_error(f"Blender executable invalid: '{blender_exe}'")
             self._display_message("Error: Blender executable path invalid.")
             return None
+
+        # Security check: Ensure the executable is actually blender
+        blender_basename = self.safe_basename(blender_exe).lower()
+        if blender_basename not in ("blender", "blender.exe"):
+            self._log_error(f"Security error: Invalid executable name '{blender_basename}' for Blender.")
+            self._display_message("Error: Invalid Blender executable name.")
+            return None
+
         if not unwrap_script_path:
             self._display_message("Error: Blender unwrap script not found.")
             return None
+
+        # Security check: Ensure the script has a .py extension
+        if not unwrap_script_path.lower().endswith(".py"):
+            self._log_error(f"Security error: Invalid script extension for '{unwrap_script_path}'. Must be .py")
+            self._display_message("Error: Invalid script extension.")
+            return None
+
 
         base, ext = os.path.splitext(input_mesh_path)
         output_suffix = settings.get("blender_unwrap_output_suffix", "_spUnwrapped")


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
The `texture_processor.py` was directly executing `texconv.exe` and `blender.exe` using paths configured in the user's settings, without validating the binary name. This could allow execution of arbitrary programs if the settings file was modified. Additionally, the unwrap script path wasn't validated for extension. Also, a bug in `test_remix_api.py` regarding mocked RequestException inheritance was fixed.

⚠️ **Risk:** The potential impact if left unfixed
Any malicious modification of the configuration file could result in arbitrary code execution, enabling an attacker to run any program under the context of the user running the plugin.

🛡️ **Solution:** How the fix addresses the vulnerability
Added basename checks for both executables (`blender` or `blender.exe`, `texconv` or `texconv.exe`) to prevent them from executing non-blender/non-texconv binaries. Also validated that the unwrap script uses a `.py` extension. New tests were added to ensure these security checks work as expected. Removed temporary patching scripts from the workspace before committing.

---
*PR created automatically by Jules for task [4641844594436161143](https://jules.google.com/task/4641844594436161143) started by @skurtyyskirts*