### PR TITLE
polish: surface subprocess errors, log hash mismatches, cache defaults

### DIFF
--- a/core.py
+++ b/core.py
@@ -814,6 +814,15 @@ class RemixConnectorPlugin(QObject):
                 m = re.search(r"([A-Z0-9]{16})$", str(linked_material_prim))
                 if m:
                     desired_root = m.group(1)
+                else:
+                    # Surfacing this at WARN level: a missed match here means the
+                    # ForcePush filename root falls back to a generic stem and the
+                    # user loses the ability to trace the texture back to the
+                    # specific Remix material via filename.
+                    self.log_warning(
+                        f"Could not extract 16-char hash from material prim "
+                        f"'{linked_material_prim}'; falling back to filename-stem heuristic."
+                    )
                 if not desired_root and exported_files:
                     first_path = next(iter(exported_files.values()))
                     stem = os.path.splitext(os.path.basename(first_path))[0]

--- a/settings_schema.py
+++ b/settings_schema.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+from functools import lru_cache
 from typing import Any, Dict, Tuple
 
 from .plugin_info import PLUGIN_ID
@@ -8,7 +9,14 @@ DEFAULT_REMIX_API_BASE_URL = "http://localhost:8011"
 SETTINGS_VERSION = 1
 
 
+@lru_cache(maxsize=4)
 def _detect_texconv_path(plugin_dir: str) -> str:
+    """Look for the bundled texconv.exe next to the plugin.
+
+    Cached because sanitize_settings() runs on every save and the file does
+    not change beneath us at runtime; without the cache we did a stat per
+    save (cheap, but pointless).
+    """
     try:
         local = os.path.join(plugin_dir, "texconv.exe")
         return local if os.path.isfile(local) else ""

--- a/texture_processor.py
+++ b/texture_processor.py
@@ -39,6 +39,12 @@ class TextureProcessor:
         else: self._log_info(f"UI Message: {msg}")
 
     @staticmethod
+    def _truncate(text, limit=400):
+        if not text: return ""
+        text = str(text).strip()
+        return text if len(text) <= limit else text[:limit].rstrip() + "...(truncated)"
+
+    @staticmethod
     def safe_basename(path):
         if not path: return ""
         try: return ntpath.basename(str(path))
@@ -182,7 +188,8 @@ class TextureProcessor:
             stderr_text = result.stderr or ""
             if result.returncode != 0 or "Error: Python script fail" in stderr_text:
                 self._log_error(f"Blender failed (Code {result.returncode}). Stderr: {stderr_text}")
-                self._display_message("Error: Blender auto-unwrap failed.")
+                detail = self._truncate(stderr_text) or f"exit code {result.returncode}"
+                self._display_message(f"Blender auto-unwrap failed: {detail}")
                 return None
             
             if os.path.exists(output_mesh_path):


### PR DESCRIPTION
## Summary

Three small UX / quality fixes:

- `texture_processor`: Blender failure message now contains the (truncated) stderr instead of `"Blender auto-unwrap failed."`.
- `core`: warn (not silently fall back) when the 16-char material-hash regex misses the linked prim path.
- `settings_schema`: `_detect_texconv_path` is `lru_cache`-d so `sanitize_settings()` does not re-stat texconv on every save.

## Why

When users hit a Blender failure, the only place the actual reason lived was the log file. Most users won't go look. Surfacing it inline saves a support round-trip.

The hash-regex silent fallback meant pushing to a material whose prim path had a non-standard format would *succeed* but with a generic filename root, breaking the user's ability to trace the texture back to the source material. A WARNING in the logs makes the failure visible without changing behavior.

The `_detect_texconv_path` cache is a micro-optimization (~ms per save) but the function was being called multiple times per `sanitize_settings()` call.

## Notes

I deliberately scoped this PR small. Items I considered but skipped:

- Type hints on `RemixAPIClient`/`TextureProcessor`/`PainterController` public methods — worth doing later as a focused PR (touches every method signature).
- Inverting the 5xx retry condition in `remix_api.py:181` — the logic is correct today; rewriting purely for readability invites bugs without fixing one.
- Lazy debug-log f-strings — micro-optimization, no measurable wall-time impact.

## Test plan

- [x] `python -m unittest discover tests` — all 48 tests pass.
- [ ] Manual: point `blender_executable_path` at a non-Blender exe; trigger auto-unwrap; verify the actual stderr text appears in the message dialog.
- [ ] Manual: ForcePush against a synthesized material prim with a non-standard ID; verify the WARN line shows up in `logs/remix_connector.log`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)