### PR TITLE
🧹 [code health improvement] Fix unused imports in dependency_manager.py

### DIFF
--- a/dependency_manager.py
+++ b/dependency_manager.py
@@ -65,8 +65,8 @@ def ensure_dependencies_installed():
 
     # Verify imports
     try:
-        import requests
-        import PIL
+        __import__("requests")
+        __import__("PIL")
         _log_info("Dependencies 'requests' and 'PIL' imported successfully.")
         return True
     except ImportError as e:


### PR DESCRIPTION
🎯 **What:** Replaced `import requests` and `import PIL` with `__import__("requests")` and `__import__("PIL")` in `dependency_manager.py`.
💡 **Why:** This removes the unused import linting warnings while preserving the functionality of checking if the dependencies were successfully added to the sys.path.
✅ **Verification:** Verified by running the full test suite (`python3 -m unittest discover tests`) which passed 83 tests.
✨ **Result:** Cleaned up unused variables and potential lint warnings without breaking dependency validation.

---
*PR created automatically by Jules for task [16480225904814321238](https://jules.google.com/task/16480225904814321238) started by @skurtyyskirts*