### PR TITLE
🧹 [code health improvement] Remove unused requests and PIL imports in dependency manager

### DIFF
--- a/dependency_manager.py
+++ b/dependency_manager.py
@@ -65,8 +65,8 @@ def ensure_dependencies_installed():
 
     # Verify imports
     try:
-        import requests
-        import PIL
+        __import__('requests')
+        __import__('PIL')
         _log_info("Dependencies 'requests' and 'PIL' imported successfully.")
         return True
     except ImportError as e:


### PR DESCRIPTION
🎯 **What:** Replaced `import requests` and `import PIL` with `__import__('requests')` and `__import__('PIL')` in `ensure_dependencies_installed()`.
💡 **Why:** This resolves unused import linter warnings by verifying package installation availability without assigning local variables.
✅ **Verification:** The test suite was run and completed successfully, proving the logic correctly handles installation verification without generating lint errors.
✨ **Result:** Cleaner code that maintains exact runtime functionality while silencing unnecessary linter warnings.

---
*PR created automatically by Jules for task [2080938793852154292](https://jules.google.com/task/2080938793852154292) started by @skurtyyskirts*