### PR TITLE
🧹 [code health improvement] Refactor UI setup in _start_worker

### DIFF
--- a/core.py
+++ b/core.py
@@ -117,6 +117,57 @@ class RemixConnectorPlugin(QObject):
         except Exception:
             return None
 
+    def _setup_progress_dialog(self, worker, title):
+        progress_dialog = None
+        try:
+            progress_dialog = QtWidgets.QProgressDialog("Working...", "Hide", 0, 0, self._get_ui_parent())
+            progress_dialog.setWindowTitle(title or PLUGIN_NAME)
+            progress_dialog.setWindowModality(QtCore.Qt.WindowModal)
+            progress_dialog.setMinimumDuration(0)
+            progress_dialog.setAutoClose(True)
+            progress_dialog.setAutoReset(True)
+            progress_dialog.setValue(0)
+            # Hide-only: we do not propagate cancel into the worker.
+            try:
+                progress_dialog.canceled.connect(progress_dialog.hide)
+            except (AttributeError, TypeError):
+                pass
+            # Free the QObject deterministically when the dialog closes.
+            try:
+                progress_dialog.setAttribute(QtCore.Qt.WA_DeleteOnClose, False)
+            except (AttributeError, TypeError):
+                pass
+
+            progress_dialog.show()
+            with self._workers_lock:
+                self._active_progress_dialogs[worker] = progress_dialog
+
+            # Connect signals directly to QObject methods so Qt routes
+            # them via QueuedConnection across threads.
+            try:
+                worker.signals.status.connect(
+                    progress_dialog.setLabelText, QtCore.Qt.QueuedConnection
+                )
+            except (AttributeError, TypeError):
+                pass
+
+            # progress: switch to determinate range on first update,
+            # then forward the value. Bind through a small helper that
+            # lives on the GUI thread. Parent it to the dialog so it
+            # is destroyed automatically when the dialog goes away.
+            helper = _ProgressBridge(progress_dialog, parent=progress_dialog)
+            try:
+                worker.signals.progress.connect(
+                    helper.on_progress, QtCore.Qt.QueuedConnection
+                )
+            except (AttributeError, TypeError):
+                pass
+        except Exception as e:
+            self.log_debug(f"Progress dialog setup failed (non-fatal): {e}")
+            progress_dialog = None
+        return progress_dialog
+
+
     def _start_worker(self, worker, on_result=None, title=None, show_progress=True):
         """
         Starts a Worker and keeps a strong reference until it finishes.
@@ -133,52 +184,7 @@ class RemixConnectorPlugin(QObject):
 
         progress_dialog = None
         if show_progress and QtWidgets and QtCore:
-            try:
-                progress_dialog = QtWidgets.QProgressDialog("Working...", "Hide", 0, 0, self._get_ui_parent())
-                progress_dialog.setWindowTitle(title or PLUGIN_NAME)
-                progress_dialog.setWindowModality(QtCore.Qt.WindowModal)
-                progress_dialog.setMinimumDuration(0)
-                progress_dialog.setAutoClose(True)
-                progress_dialog.setAutoReset(True)
-                progress_dialog.setValue(0)
-                # Hide-only: we do not propagate cancel into the worker.
-                try:
-                    progress_dialog.canceled.connect(progress_dialog.hide)
-                except (AttributeError, TypeError):
-                    pass
-                # Free the QObject deterministically when the dialog closes.
-                try:
-                    progress_dialog.setAttribute(QtCore.Qt.WA_DeleteOnClose, False)
-                except (AttributeError, TypeError):
-                    pass
-
-                progress_dialog.show()
-                with self._workers_lock:
-                    self._active_progress_dialogs[worker] = progress_dialog
-
-                # Connect signals directly to QObject methods so Qt routes
-                # them via QueuedConnection across threads.
-                try:
-                    worker.signals.status.connect(
-                        progress_dialog.setLabelText, QtCore.Qt.QueuedConnection
-                    )
-                except (AttributeError, TypeError):
-                    pass
-
-                # progress: switch to determinate range on first update,
-                # then forward the value. Bind through a small helper that
-                # lives on the GUI thread. Parent it to the dialog so it
-                # is destroyed automatically when the dialog goes away.
-                helper = _ProgressBridge(progress_dialog, parent=progress_dialog)
-                try:
-                    worker.signals.progress.connect(
-                        helper.on_progress, QtCore.Qt.QueuedConnection
-                    )
-                except (AttributeError, TypeError):
-                    pass
-            except Exception as e:
-                self.log_debug(f"Progress dialog setup failed (non-fatal): {e}")
-                progress_dialog = None
+            progress_dialog = self._setup_progress_dialog(worker, title)
 
         # Cleanup must run on the GUI thread so it can touch QWidgets.
         try:


### PR DESCRIPTION
🎯 **What:** Extracted the PySide/PyQt QProgressDialog creation and configuration logic from `_start_worker` into a dedicated `_setup_progress_dialog` method.

💡 **Why:** `_start_worker` was very large and complex, primarily due to the heavy Qt UI initialization block. Moving this logic to a helper method significantly reduces the size and cognitive load of the core thread management function, making both methods easier to read and maintain.

✅ **Verification:** Used `grep` and `git diff` to ensure the logic was identically migrated to the new method and correctly called from the original location. Ran the full unit test suite (`python3 -m unittest discover tests`) successfully, confirming no regressions.

✨ **Result:** A cleaner, more focused `_start_worker` method and a cleanly abstracted UI setup process, preserving identical functionality.

---
*PR created automatically by Jules for task [16961599966107807154](https://jules.google.com/task/16961599966107807154) started by @skurtyyskirts*