### PR TITLE
🧹 [code health improvement] Remove unused dependency_manager import from core.py

### DIFF
--- a/core.py
+++ b/core.py
@@ -14,7 +14,6 @@ from concurrent.futures import ThreadPoolExecutor
 _PIPELINE_MAX_WORKERS = min(4, (os.cpu_count() or 4))
 
 # Local imports
-from . import dependency_manager
 from .qt_utils import QObject, Signal, Slot, QThread, QRunnable, QThreadPool, QtWidgets, QtCore, QT_BINDING
 from .plugin_info import PLUGIN_NAME, PLUGIN_VERSION, PLUGIN_REPO_URL, PLUGIN_DESCRIPTION
 from .remix_api import RemixAPIClient, REMIX_ATTR_SUFFIX_TO_PBR_MAP, PBR_TO_REMIX_INGEST_VALIDATION_TYPE_MAP


### PR DESCRIPTION
🎯 **What:** Removed the unused `dependency_manager` import from `core.py`.
💡 **Why:** Cleaning up unused imports improves code readability, prevents unnecessary namespace clutter, and maintains code hygiene. `dependency_manager` is properly imported and utilized in `__init__.py` for setup before `core.py` is loaded.
✅ **Verification:** Ran the full unittest suite locally to confirm that the change is safe and preserves existing functionality.
✨ **Result:** A cleaner `core.py` file with no unused imports.

---
*PR created automatically by Jules for task [11635724245884752128](https://jules.google.com/task/11635724245884752128) started by @skurtyyskirts*