### PR TITLE
🧹 [code health improvement] Remove unused imports in core.py

### DIFF
--- a/core.py
+++ b/core.py
@@ -14,8 +14,7 @@ from concurrent.futures import ThreadPoolExecutor
 _PIPELINE_MAX_WORKERS = min(4, (os.cpu_count() or 4))
 
 # Local imports
-from . import dependency_manager
-from .qt_utils import QObject, Signal, Slot, QThread, QRunnable, QThreadPool, QtWidgets, QtCore, QT_BINDING
+from .qt_utils import QObject, Slot, QThreadPool, QtWidgets, QtCore, QT_BINDING
 from .plugin_info import PLUGIN_NAME, PLUGIN_VERSION, PLUGIN_REPO_URL, PLUGIN_DESCRIPTION
 from .remix_api import RemixAPIClient, REMIX_ATTR_SUFFIX_TO_PBR_MAP, PBR_TO_REMIX_INGEST_VALIDATION_TYPE_MAP
 from .texture_processor import TextureProcessor


### PR DESCRIPTION
🎯 What: Removed `dependency_manager`, `Signal`, `QThread`, and `QRunnable` from imports in `core.py` because they are not used within the file.
💡 Why: Cleaning up unused imports improves maintainability, readability and satisfies static analysis tools.
✅ Verification: Ran `python3 -m unittest discover tests` and verified that the test suite still passes successfully.
✨ Result: `core.py` is now cleaner and devoid of unused references, improving overall code health.

---
*PR created automatically by Jules for task [5817921875171105641](https://jules.google.com/task/5817921875171105641) started by @skurtyyskirts*