### PR TITLE
🔒 Fix: Prevent TLS verification bypass via absolute URL endpoints

### DIFF
--- a/remix_api.py
+++ b/remix_api.py
@@ -167,7 +167,11 @@ class RemixAPIClient:
         # local-loopback HTTP (Remix's typical configuration). Hostname is
         # parsed via urlparse to avoid substring spoofing (localhost.evil.com).
         if verify_ssl is None:
-            verify_ssl = not _is_local_host(current_api_base)
+            # Enforce verify=True if url_endpoint is an absolute URL
+            if urllib.parse.urlparse(url_endpoint).netloc:
+                verify_ssl = True
+            else:
+                verify_ssl = not _is_local_host(current_api_base)
 
         base_headers = {'Accept': 'application/lightspeed.remix.service+json; version=1.0'}
         if json_payload is not None and 'Content-Type' not in (headers or {}):

--- a/tests/test_remix_api.py
+++ b/tests/test_remix_api.py
@@ -86,6 +86,21 @@ class TestTLSPolicy(unittest.TestCase):
         # Hostname comparison is case-insensitive
         self.assertFalse(self._capture_verify("http://LOCALHOST:8011"))
 
+    def test_absolute_url_endpoint_uses_verify_true(self):
+        # Enforce verify=True if the url_endpoint is an absolute URL, to prevent bypasses
+        client = _make_client("http://localhost:8011")
+        sess = _mock_session()
+        sess.request.return_value = _mock_response()
+
+        with patch.object(client, "_get_session", return_value=sess):
+            client.make_request("GET", "https://evil.com/test", retries=1)
+            _, kwargs = sess.request.call_args
+            self.assertTrue(kwargs.get("verify"))
+
+            client.make_request("GET", "//evil.com", retries=1)
+            _, kwargs = sess.request.call_args
+            self.assertTrue(kwargs.get("verify"))
+
 
 class TestBaseUrlValidation(unittest.TestCase):
     """make_request must reject URLs that aren't http/https or lack a host."""


### PR DESCRIPTION
🎯 What:
Fixed a vulnerability in RemixAPIClient.make_request where passing an absolute URL endpoint to an API client configured with a local base URL could bypass SSL/TLS verification. The patch detects if the url_endpoint contains a network location and correctly enforces verify_ssl=True.

⚠️ Risk:
A malicious actor could potentially intercept or alter requests by exploiting the local-loopback bypass mechanism if an absolute, remote URL was dynamically passed to the make_request method, enabling Man-in-the-Middle (MitM) attacks against what should be secure remote communication.

🛡️ Solution:
Updated the URL parsing logic to inspect the netloc of the url_endpoint. If it's an absolute URL, SSL verification is explicitly mandated (verify_ssl = True) when the caller hasn't explicitly specified a policy. Also added a comprehensive unit test to verify that requests targeting absolute URLs correctly enforce TLS.

---
*PR created automatically by Jules for task [12298274473569414351](https://jules.google.com/task/12298274473569414351) started by @skurtyyskirts*