### PR TITLE
🧹 [code health improvement] Remove unused imports in core.py

### DIFF
--- a/core.py
+++ b/core.py
@@ -14,8 +14,7 @@ from concurrent.futures import ThreadPoolExecutor
 _PIPELINE_MAX_WORKERS = min(4, (os.cpu_count() or 4))
 
 # Local imports
-from . import dependency_manager
-from .qt_utils import QObject, Signal, Slot, QThread, QRunnable, QThreadPool, QtWidgets, QtCore, QT_BINDING
+from .qt_utils import QObject, Slot, QThreadPool, QtWidgets, QtCore, QT_BINDING
 from .plugin_info import PLUGIN_NAME, PLUGIN_VERSION, PLUGIN_REPO_URL, PLUGIN_DESCRIPTION
 from .remix_api import RemixAPIClient, REMIX_ATTR_SUFFIX_TO_PBR_MAP, PBR_TO_REMIX_INGEST_VALIDATION_TYPE_MAP
 from .texture_processor import TextureProcessor


### PR DESCRIPTION
🎯 What:
Removed unused `dependency_manager` import and unused `Signal`, `QThread`, and `QRunnable` imports from `qt_utils` in `core.py`.

💡 Why:
Cleaning up unused imports improves code readability and maintains codebase hygiene by reducing clutter and potential confusion.

✅ Verification:
- Ran the full test suite (`python3 -m unittest discover tests`) to ensure functionality is unaffected.
- Ran format/lint checks (`flake8 core.py`) to confirm no new linting errors were introduced.

✨ Result:
Cleaner, more maintainable code without changing existing behavior.

---
*PR created automatically by Jules for task [6690051301727065718](https://jules.google.com/task/6690051301727065718) started by @skurtyyskirts*