### PR TITLE
🧹 [code health improvement: suppress false positive unused import]

### DIFF
--- a/dependency_manager.py
+++ b/dependency_manager.py
@@ -65,8 +65,8 @@ def ensure_dependencies_installed():
 
     # Verify imports
     try:
-        import requests
-        import PIL
+        import requests  # noqa: F401
+        import PIL  # noqa: F401
         _log_info("Dependencies 'requests' and 'PIL' imported successfully.")
         return True
     except ImportError as e:


### PR DESCRIPTION
🎯 What
Added `# noqa: F401` to `import requests` and `import PIL` in `dependency_manager.py`.

💡 Why
The linter incorrectly flags these imports as unused, but they are deliberately placed in a try/except block to verify the successful loading of vendored dependencies. Suppressing the warning maintains clean CI/CD while preserving critical runtime validation logic.

✅ Verification
Ran full unittest suite successfully.

✨ Result
Linter warnings are suppressed, and the original runtime behavior remains unchanged.

---
*PR created automatically by Jules for task [13010164407900311327](https://jules.google.com/task/13010164407900311327) started by @skurtyyskirts*