### PR TITLE
chore: enable GitHub Pro feature files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default code owner for review-on-PR (auto-requested when branch protection enabled)
+* @skurtyyskirts

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [skurtyyskirts]

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Report a defect or regression
+title: '[bug] '
+labels: ['bug']
+---
+
+## Summary
+
+## Reproduction steps
+
+1.
+2.
+3.
+
+## Expected behavior
+
+## Actual behavior
+
+## Environment
+
+- OS / GPU:
+- Python version:
+- Commit / build:
+
+## Logs / screenshots

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Propose an enhancement
+title: '[feat] '
+labels: ['enhancement']
+---
+
+## Problem
+
+## Proposed solution
+
+## Alternatives considered
+
+## Additional context

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Summary
+
+<!-- What does this PR change and why? -->
+
+## Changes
+
+- 
+
+## Testing
+
+<!-- Commands run, scenarios verified, screenshots. -->
+
+## Checklist
+
+- [ ] Changes are scoped and minimal
+- [ ] No secrets, large binaries, or generated artifacts committed
+- [ ] CHANGELOG / docs updated if user-facing
+- [ ] Linked issue: #

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    labels: [dependencies, automerge]
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns: ["*"]
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    labels: [dependencies, automerge]
+    open-pull-requests-limit: 5
+    groups:
+      python:
+        patterns: ["*"]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,33 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '37 4 * * 1'
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (Python)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: python
+          queries: security-and-quality
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:python"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,21 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Report security vulnerabilities **privately** via this repository's `Security` tab using GitHub Security Advisories. Do not open a public issue.
+
+Include:
+- Description of the vulnerability
+- Reproduction steps or proof-of-concept
+- Affected versions or commits
+- Suggested fix (optional)
+
+Acknowledgement within 7 days.
+
+## Supported Versions
+
+Only the `main` branch is supported. Historical builds, patches, traces, and test artifacts in the repository are unsupported.


### PR DESCRIPTION
## Summary

Brings this repo up to the **GitHub Pro** feature baseline. No code changes — only `.github/` config and a `SECURITY.md`.

## Files added

| Path | Purpose |
|---|---|
| `.github/CODEOWNERS` | Auto-requests `@skurtyyskirts` review. |
| `.github/FUNDING.yml` | "Sponsor" button. |
| `.github/dependabot.yml` | Weekly GH Actions + pip updates, grouped, auto-merge label. |
| `.github/workflows/dependency-review.yml` | Pro-unlocked: fails PRs introducing vulnerable deps. |
| `.github/workflows/codeql.yml` | Weekly + on-PR Python CodeQL scan. |
| `SECURITY.md` | Vulnerability reporting policy. |
| `.github/PULL_REQUEST_TEMPLATE.md` | Generic PR template. |
| `.github/ISSUE_TEMPLATE/bug_report.md` | Bug-report template. |
| `.github/ISSUE_TEMPLATE/feature_request.md` | Feature-request template. |
| `.github/ISSUE_TEMPLATE/config.yml` | Issue-template config. |

## Admin-scope items (you do in UI)

1. **Settings → Code security**: Dependabot alerts/updates, secret scanning + push protection.
2. **Settings → Branches → Add rule for `main`**: require PR + 1 approval, status checks (`Dependency Review`, `CodeQL`), CODEOWNERS review, linear history.
3. **Settings → General → Pull Requests**: squash-only, auto-delete branches.
4. **Settings → Sponsorship**: optional.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SwvzZro7jJTJMXNCFV994V)_