### PR TITLE
Fix failed workflows: GH_TOKEN and linear-sync deps

### DIFF
--- a/.github/workflows/idea-generation.yml
+++ b/.github/workflows/idea-generation.yml
@@ -35,15 +35,15 @@ jobs:
 
           context = f"""# Project: Substance2Remix
 
-## CLAUDE.md
-{claude_md[:3000]}
+          ## CLAUDE.md
+          {claude_md[:3000]}
 
-## WHITEBOARD (current hypotheses and blockers)
-{whiteboard[:2000]}
+          ## WHITEBOARD (current hypotheses and blockers)
+          {whiteboard[:2000]}
 
-## Last 20 CHANGELOG entries
-{changelog_context}
-"""
+          ## Last 20 CHANGELOG entries
+          {changelog_context}
+          """
           Path("/tmp/context.txt").write_text(context, encoding="utf-8")
           print("Context built.")
           EOF
@@ -61,16 +61,16 @@ jobs:
 
           prompt = f"""{context}
 
----
+          ---
 
-Given the current project state above, identify the 3–5 most promising **unexplored or under-explored** approaches that could resolve the active blocker or advance the project.
+          Given the current project state above, identify the 3-5 most promising **unexplored or under-explored** approaches that could resolve the active blocker or advance the project.
 
-For each idea:
-1. State the hypothesis clearly (1–2 sentences)
-2. Explain why it's likely to help given the current evidence
-3. Describe the concrete first step to test it
+          For each idea:
+          1. State the hypothesis clearly (1-2 sentences)
+          2. Explain why it's likely to help given the current evidence
+          3. Describe the concrete first step to test it
 
-Format as a numbered list. Be specific to Substance2Remix's codebase and blockers — avoid generic suggestions."""
+          Format as a numbered list. Be specific to Substance2Remix's codebase and blockers - avoid generic suggestions."""
 
           payload = {
               "model": "claude-sonnet-4-5",
@@ -143,6 +143,7 @@ Format as a numbered list. Be specific to Substance2Remix's codebase and blocker
       - name: Append ideas to CHANGELOG.md and open PR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           DATE=$(date +%Y-%m-%d)
           BRANCH="bot/ideas-${DATE}"
@@ -153,7 +154,7 @@ Format as a numbered list. Be specific to Substance2Remix's codebase and blocker
           IDEAS=$(cat /tmp/ideas.txt)
           cat >> CHANGELOG.md << MARKDOWN
 
-          ## Auto-Generated Ideas — ${DATE}
+          ## Auto-Generated Ideas - ${DATE}
 
           ${IDEAS}
           MARKDOWN

--- a/.github/workflows/idea-generation.yml
+++ b/.github/workflows/idea-generation.yml
@@ -35,15 +35,15 @@ jobs:
 
           context = f"""# Project: Substance2Remix
 
-          ## CLAUDE.md
-          {claude_md[:3000]}
+## CLAUDE.md
+{claude_md[:3000]}
 
-          ## WHITEBOARD (current hypotheses and blockers)
-          {whiteboard[:2000]}
+## WHITEBOARD (current hypotheses and blockers)
+{whiteboard[:2000]}
 
-          ## Last 20 CHANGELOG entries
-          {changelog_context}
-          """
+## Last 20 CHANGELOG entries
+{changelog_context}
+"""
           Path("/tmp/context.txt").write_text(context, encoding="utf-8")
           print("Context built.")
           EOF
@@ -61,16 +61,16 @@ jobs:
 
           prompt = f"""{context}
 
-          ---
+---
 
-          Given the current project state above, identify the 3-5 most promising **unexplored or under-explored** approaches that could resolve the active blocker or advance the project.
+Given the current project state above, identify the 3–5 most promising **unexplored or under-explored** approaches that could resolve the active blocker or advance the project.
 
-          For each idea:
-          1. State the hypothesis clearly (1-2 sentences)
-          2. Explain why it's likely to help given the current evidence
-          3. Describe the concrete first step to test it
+For each idea:
+1. State the hypothesis clearly (1–2 sentences)
+2. Explain why it's likely to help given the current evidence
+3. Describe the concrete first step to test it
 
-          Format as a numbered list. Be specific to Substance2Remix's codebase and blockers - avoid generic suggestions."""
+Format as a numbered list. Be specific to Substance2Remix's codebase and blockers — avoid generic suggestions."""
 
           payload = {
               "model": "claude-sonnet-4-5",
@@ -154,7 +154,7 @@ jobs:
           IDEAS=$(cat /tmp/ideas.txt)
           cat >> CHANGELOG.md << MARKDOWN
 
-          ## Auto-Generated Ideas - ${DATE}
+          ## Auto-Generated Ideas — ${DATE}
 
           ${IDEAS}
           MARKDOWN

--- a/.github/workflows/linear-sync.yml
+++ b/.github/workflows/linear-sync.yml
@@ -27,6 +27,9 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Install dependencies
+        run: pip install requests
+
       - name: Sync to Linear
         env:
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}


### PR DESCRIPTION
Two targeted CI fixes:

1. **`.github/workflows/idea-generation.yml`** — Add `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` alongside the existing `GITHUB_TOKEN` env in the "Append ideas to CHANGELOG.md and open PR" step. The `gh` CLI prefers `GH_TOKEN`; without it, `gh pr create` fails to authenticate.

2. **`.github/workflows/linear-sync.yml`** — Insert an `Install dependencies` step (`pip install requests`) after `actions/setup-python@v5` and before running `python linear/sync.py`, so the sync script's `requests` import resolves.

No other changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_014XHeq7yb7bJLieyNwAD4cL)_