### PR TITLE
🧹 [code health improvement] Split `make_request` setup and execution

### DIFF
--- a/remix_api.py
+++ b/remix_api.py
@@ -176,6 +176,22 @@ class RemixAPIClient:
 
         self._log_debug(f"API Request: {method.upper()} {full_url}")
 
+        return self._execute_request(
+            method=method,
+            full_url=full_url,
+            effective_headers=effective_headers,
+            json_payload=json_payload,
+            params=params,
+            effective_timeout=effective_timeout,
+            verify_ssl=verify_ssl,
+            retries=retries,
+            delay=delay
+        )
+
+    def _execute_request(self, method, full_url, effective_headers, json_payload, params, effective_timeout, verify_ssl, retries, delay):
+        """
+        Executes the prepared request with retry logic.
+        """
         last_error_message = "Request failed after multiple retries."
         session = self._get_session()
 


### PR DESCRIPTION
🎯 **What:** The `make_request` method in `remix_api.py` was overly complex, managing both request preparation (URL building, header construction) and execution (the retry loop, exception handling). It has been split into `make_request` (setup) and `_execute_request` (execution).

💡 **Why:** By extracting the retry loop and actual request invocation into `_execute_request`, we dramatically reduce the cognitive load of `make_request`. This separation of concerns improves testability and readability, adhering to single-responsibility principles.

✅ **Verification:** 
- The refactored code has been thoroughly verified. 
- A full test suite run (`python3 -m unittest discover tests`) passed with all 83 tests succeeding.
- The structure of the refactored code was visually inspected to ensure variables and references were accurately passed.

✨ **Result:** A more maintainable, decoupled network API client implementation while preserving 100% of the existing retry, fallback, and header behaviors.

---
*PR created automatically by Jules for task [8682848624547865848](https://jules.google.com/task/8682848624547865848) started by @skurtyyskirts*