### PR TITLE
Enable GitHub Copilot coding agent (setup steps + instructions)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,15 @@
+# Copilot Instructions — Substance2Remix
+
+A **Substance Painter plugin** (Python) that imports/exports textures between Substance Painter and the RTX Remix Toolkit.
+
+## Orientation
+- Read `CLAUDE.md` first.
+- Core modules: `core.py`, `remix_api.py` (REST client for the Remix Toolkit), `painter_controller.py`, `texture_processor.py`, `async_utils.py`. UI uses PySide/Qt (`*_dialog.py`, `qt_utils.py`).
+- Tests live in `tests/` — run them before claiming work complete.
+
+## Conventions
+- Match the style of the file you are editing; keep functions small and single-purpose.
+- Don't break the Remix round-trip pipeline (`ingest_texture` → `update_textures_batch` → `save_layer`) or the request/retry logic in `remix_api.py`.
+- Guard Qt usage behind the existing `QT_AVAILABLE` checks so headless tests keep working.
+- Add or update tests when changing behavior; update `CHANGELOG.md` for notable changes.
+- Never commit secrets, API keys, or vendored binaries you didn't intend to.

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,31 @@
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+          if [ -f pyproject.toml ]; then pip install -e . || true; fi


### PR DESCRIPTION
## Summary
Adds the two files the GitHub Copilot coding agent relies on, which this repo was missing:
- `.github/workflows/copilot-setup-steps.yml` — provisions the agent's ephemeral Python env (installs `requirements.txt` / `pyproject.toml` when present).
- `.github/copilot-instructions.md` — repo-specific guidance: orientation (CLAUDE.md, core modules, tests), and the constraint to preserve the Remix round-trip (`ingest_texture` → `update_textures_batch` → `save_layer`) and `QT_AVAILABLE` guards.

## Why
The sibling RTX repos already ship these. This brings Substance2Remix in line so the Copilot coding agent produces higher-quality PRs here.

## Notes
This is the surgical, Copilot-only subset of the older "Enable GitHub Pro automation pack" PR (#105), which is now stale and has merge conflicts. No workflows requiring secrets are added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJV2EGQCdn7DcsRAnpHH6a)_