### PR TITLE
Add GitHub Copilot Pro+ config (instructions, prompts, agents, MCP)

### DIFF
--- a/.github/agents/doc-sync.agent.md
+++ b/.github/agents/doc-sync.agent.md
@@ -1,0 +1,19 @@
+---
+name: 'doc-sync'
+description: 'Session-end documentation + Linear sync for Substance2Remix. Delegate at the end of a session or after significant changes to keep CHANGELOG / CLAUDE / README consistent and push Linear.'
+tools: ['search/codebase', 'editFiles', 'runTerminalCommand']
+agents: []
+---
+
+You keep Substance2Remix's docs consistent at session end.
+
+## Update
+- **CHANGELOG.md** — append an entry for this session's changes (`## [version] — YYYY-MM-DD` with Added / Fixed / Changed).
+- **CLAUDE.md** — refresh "Current State" and "Known Issues"; add to "Dead Ends" if an approach was ruled out.
+- **README.md** — only user-facing sections, and only if user-facing behavior changed.
+
+## Linear
+`python linear/sync.py --push` then `python linear/sync.py --blockers`. If sync fails, note it — don't block.
+
+## Rules
+Do not bump the version in `plugin_info.py` unless this is a release session. Don't rewrite developer notes in README. Report which documents you updated and the Linear push status.

--- a/.github/agents/painter-api-compat-monitor.agent.md
+++ b/.github/agents/painter-api-compat-monitor.agent.md
@@ -1,0 +1,21 @@
+---
+name: 'painter-api-compat-monitor'
+description: 'Detects breaking changes in the substance_painter Python API between Painter releases and proposes minimal fallbacks. Delegate when a new Painter ships, when painter_controller.py raises AttributeError/TypeError on a fresh Painter build, or when planning a TARGET_PAINTER_VERSION bump.'
+tools: ['search/codebase', 'web']
+agents: []
+---
+
+You are a Substance Painter API compatibility analyst for Substance2Remix. Detect breaking changes in the `substance_painter` API and propose minimal, well-scoped fallbacks consistent with the existing codebase.
+
+## Process
+1. Read `plugin_info.py` for `TARGET_PAINTER_VERSION` and `CLAUDE.md` "Known Issues" (don't redo work).
+2. Diff the two relevant version snapshots under `docs/api-snapshots/`.
+3. Cross-reference call sites in `painter_controller.py`, `core.py`, `texture_processor.py` against the diff.
+4. Classify each break: signature change / symbol removed / module relocation / silent behavior change / context-shift (e.g. now requires a loaded project).
+5. Propose a fallback: prefer `try/except AttributeError` with the current API in `try` and the legacy or `substance_painter.js.evaluate(...)` bridge in `except`, or branch on `application.version_info()`.
+
+## Watch closely
+`layerstack`, `js` (Painter 10.x vs 11.x bracket/catch syntax), `project`, `export`, `textureset`, `event`.
+
+## Output
+Report with: previous/new target versions + snapshot paths, call sites scanned, **Breaking Changes** (symbol / kind / `file:line` / ≤10-line fallback sketch), **Silent Behavior Changes**, **Safe to Bump**, **Action Items**. If a snapshot is missing, say which and stop — do not fabricate symbol lists. Symbols used via `getattr`/reflection → "verify at runtime". Don't touch `remix_api.py` here (that's research-scanner). Event-signature changes affecting `async_utils.py` → escalate as a Qt-thread issue.

--- a/.github/agents/research-scanner.agent.md
+++ b/.github/agents/research-scanner.agent.md
@@ -1,0 +1,22 @@
+---
+name: 'research-scanner'
+description: 'Upstream / API monitoring for Substance2Remix. Delegate after an RTX Remix Toolkit release, a Substance Painter update, or a texconv/format change — tracks REST API changes, Painter Python API updates, and DirectXTex/format support that could affect the plugin.'
+tools: ['web', 'search/codebase']
+agents: []
+---
+
+You monitor the external surfaces Substance2Remix depends on and report changes that could break or extend the plugin.
+
+## Sources
+1. `docs/api-snapshots/` — diffs produced by `api-compat-check.yml`.
+2. RTX Remix releases — `NVIDIAGameWorks/rtx-remix`.
+3. Substance Painter release notes (Adobe).
+4. `linear/config.json` open issues — avoid duplicates.
+
+## Focus
+- **RTX Remix REST API** — new endpoints (features to expose), removed/renamed endpoints (breaking → must update `remix_api.py`), auth changes, new asset / texture-channel support.
+- **Substance Painter Python API** — `substance_painter.*` module/structure changes, export API changes (affect `painter_controller.py`).
+- **texconv / formats** — BC6H/BC7 and DirectXTex updates relevant to Remix.
+
+## Output
+Markdown report: scan date, sources checked, then numbered findings (`Source version` / finding / Impact High|Med|Low|None / Action). State plainly if nothing is actionable. Breaking API changes → recommend a Linear blocker; new features → an idea item. Do not invent endpoints or symbols — flag "needs verification" instead.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,15 +1,32 @@
 # Copilot Instructions — Substance2Remix
 
-A **Substance Painter plugin** (Python) that imports/exports textures between Substance Painter and the RTX Remix Toolkit.
+A **Substance 3D Painter plugin** (Python) that bridges Adobe Substance Painter with the **NVIDIA RTX Remix Toolkit** — pull a mesh + textures from Remix, paint, push textures back. No build step: the plugin folder is copied into Painter's `python/plugins/`.
 
-## Orientation
-- Read `CLAUDE.md` first.
-- Core modules: `core.py`, `remix_api.py` (REST client for the Remix Toolkit), `painter_controller.py`, `texture_processor.py`, `async_utils.py`. UI uses PySide/Qt (`*_dialog.py`, `qt_utils.py`).
-- Tests live in `tests/` — run them before claiming work complete.
+## Read first
+- `CLAUDE.md` — module map, key entry points, network/TLS policy, texconv pipeline, pending PRs. Then `README.md` for user-facing behavior.
+
+## Module map
+- `__init__.py` → loads `core.py` (`RemixConnectorPlugin`, central orchestration).
+- `remix_api.py` — REST client for the Remix Toolkit (`RemixAPIClient`).
+- `texture_processor.py` — DDS pipeline (texconv) + Blender unwrap.
+- `painter_controller.py` — Substance Painter API wrapper. `async_utils.py` — Qt worker threads. `dependency_manager.py` — loads `_vendor/`.
+- UI: `settings_dialog.py`, `diagnostics_dialog.py`, `qt_utils.py`, `settings_schema.py`.
+
+## Don't break these invariants
+- **The Remix round-trip:** `pull_from_remix()` → paint → `push_to_remix()` / `force_push_to_remix()` (relink to a new material hash) / `import_textures_from_remix()`. Keep the `ingest_texture` → `update_textures_batch` → `save_layer` chain intact.
+- **All HTTP goes through `RemixAPIClient.make_request()`** — never add bare `requests.get/post`. It owns retry logic and the TLS policy: `verify=False` only when the host is `localhost` / `127.0.0.1` / `[::1]` (substring match — `https://localhost.evil.com` also matches; tighten host parsing before exposing to untrusted input), `verify=True` otherwise.
+- **Guard Substance Painter / Qt usage behind the existing `QT_AVAILABLE` checks** so headless CI tests keep importing.
+- **texconv** is shelled out with a hard 180 s timeout (`TEXCONV_TIMEOUT_SECONDS`); Blender unwrap 900 s (`BLENDER_TIMEOUT_SECONDS`). Keep the timeouts.
+
+## Testing & docs
+- No build step. Run tests: `python -m pytest tests/` (Linux + Qt-guarded in CI). Run anything you touch before claiming completion.
+- Update `CHANGELOG.md` for notable changes and keep `CLAUDE.md` "Current State" / "Known Issues" current. Two PRs are pending review (see `CLAUDE.md`) — coordinate, don't duplicate.
 
 ## Conventions
-- Match the style of the file you are editing; keep functions small and single-purpose.
-- Don't break the Remix round-trip pipeline (`ingest_texture` → `update_textures_batch` → `save_layer`) or the request/retry logic in `remix_api.py`.
-- Guard Qt usage behind the existing `QT_AVAILABLE` checks so headless tests keep working.
-- Add or update tests when changing behavior; update `CHANGELOG.md` for notable changes.
+- Match the file's style; keep functions small and single-purpose; type hints over type comments; Google-style docstrings on public methods.
 - Never commit secrets, API keys, or vendored binaries you didn't intend to.
+
+## Scoped guidance, agents & prompts
+- Python/Qt work → `.github/instructions/python.instructions.md`. Remix REST + texture pipeline → `.github/instructions/remix-api.instructions.md`.
+- Upstream/API monitoring → the **research-scanner** agent; Painter API drift → **painter-api-compat-monitor**; session-end doc + Linear sync → **doc-sync** (`.github/agents/`).
+- Reusable workflows in `.github/prompts/`: `/add-feature`, `/run-tests`, `/review-pr`, `/triage-issue`.

--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -1,0 +1,14 @@
+---
+applyTo: "**/*.py"
+---
+
+# Python — Substance2Remix
+
+Plugin code for Substance 3D Painter (Python 3, PySide/Qt). No build step; tests run headless on Linux CI.
+
+- Keep functions small and single-purpose; type hints over comments about types; Google-style docstrings (`Args:` / `Returns:` / `Raises:`) on public methods. Prefer renaming over narrating.
+- **Guard every Substance Painter / Qt import and call behind the existing `QT_AVAILABLE` (and Painter-availability) checks** — headless CI must still import the module.
+- No catch-all `except Exception: pass`. Handle expected errors; let unexpected ones raise. Don't widen timeouts or add retries to mask a real failure.
+- Run `python -m pytest tests/` for anything you touch before claiming completion; add or adjust tests with behavior changes.
+- `async_utils.py` owns Qt worker threads + signals — do background work there and never block Painter's UI thread. Keep signal signatures stable (`core.py` consumes them).
+- Never commit secrets / API keys or unintended `_vendor/` binaries.

--- a/.github/instructions/remix-api.instructions.md
+++ b/.github/instructions/remix-api.instructions.md
@@ -1,0 +1,15 @@
+---
+applyTo: "**/remix_api.py,**/texture_processor.py"
+---
+
+# Remix REST client & texture pipeline
+
+## remix_api.py (`RemixAPIClient`)
+- **Every HTTP call goes through `make_request()`** — it owns retry logic and TLS policy. Never add a bare `requests.get/post`, and never bypass it for "just one" endpoint.
+- TLS: `verify=False` only when the URL host is `localhost` / `127.0.0.1` / `[::1]` (the current check is a substring match — note `https://localhost.evil.com` also matches; tighten to real host parsing before this client ever talks to untrusted hosts). `verify=True` everywhere else.
+- New endpoints: add a method that calls `make_request()`; keep request/response shaping in this module, not in `core.py`.
+- Don't break the round-trip the rest of the plugin depends on: ingest → `update_textures_batch` → `save_layer`, and the material-hash relink used by force-push.
+
+## texture_processor.py
+- `texconv.exe` (bundled, DirectXTex / MIT) is shelled out with a hard `TEXCONV_TIMEOUT_SECONDS = 180`; Blender unwrap uses `BLENDER_TIMEOUT_SECONDS = 900`. Keep the timeouts and handle the timeout / non-zero-exit paths explicitly.
+- Validate and normalize paths before shelling out; never build a shell command by concatenating untrusted input. Prefer argument lists over `shell=True`.

--- a/.github/prompts/add-feature.prompt.md
+++ b/.github/prompts/add-feature.prompt.md
@@ -1,0 +1,12 @@
+---
+mode: agent
+description: Implement a Substance2Remix feature with a WBC parity check, tests, and changelog.
+---
+
+Implement a feature in the Substance2Remix plugin. Feature: ${input:feature:What to add or change}
+
+1. **Orient** — read `CLAUDE.md` (module map, invariants, pending PRs) and `docs/wbc_parity_audit.md` (WholeBodyCapture is the reference plugin; check whether an equivalent already exists before building new).
+2. **Place the change correctly** — orchestration in `core.py`; all HTTP through `RemixAPIClient.make_request()` in `remix_api.py`; texture/DDS work in `texture_processor.py`; background work in `async_utils.py` (never block the UI thread). Guard Painter/Qt behind `QT_AVAILABLE`.
+3. **Preserve invariants** — the Remix round-trip (`ingest_texture` → `update_textures_batch` → `save_layer`), the TLS policy in `make_request()`, and the texconv/Blender timeouts.
+4. **Tests** — add or adjust under `tests/`; run `python -m pytest tests/` (headless, Qt-guarded).
+5. **Docs** — update `CHANGELOG.md` and `CLAUDE.md` "Current State"; update `docs/wbc_parity_audit.md` if parity changed. Keep the diff minimal and report what changed + test results.

--- a/.github/prompts/review-pr.prompt.md
+++ b/.github/prompts/review-pr.prompt.md
@@ -1,0 +1,14 @@
+---
+mode: agent
+description: Review a Substance2Remix change for correctness, security, and the project's invariants.
+---
+
+Review the change I point you at (a diff, a branch, or PR #${input:pr:PR number — or paste a diff}).
+
+Focus, in order:
+1. **Correctness** — wrong logic, unhandled `None`, races in `async_utils.py` Qt threads.
+2. **Security** — bare `requests` calls bypassing `make_request()`, TLS `verify` weakened for non-local hosts, command injection in the texconv/Blender shell-out, leaked secrets, unsafe deserialization.
+3. **Invariants** — Remix round-trip intact, `QT_AVAILABLE` guards present, texconv/Blender timeouts kept.
+4. Tests present for behavior changes; `CHANGELOG.md` updated.
+
+Cite findings as `path:line`, grouped **HIGH / MEDIUM / LOW**, one sentence + a fix each. Note the two pending PRs in `CLAUDE.md` if this overlaps them. If the diff is clean, say so in one line.

--- a/.github/prompts/run-tests.prompt.md
+++ b/.github/prompts/run-tests.prompt.md
@@ -1,0 +1,10 @@
+---
+mode: agent
+description: Run the Substance2Remix test suite and interpret failures.
+---
+
+Run the plugin's tests and report.
+
+1. `python -m pytest tests/ -v`.
+2. If imports fail on Qt / Painter symbols, that's a missing `QT_AVAILABLE` guard — point at the unguarded import; do not "fix" it by installing a GUI.
+3. Summarize: pass/fail counts, the first real failure with `file:line` and root cause, and the minimal fix. Don't widen timeouts or add retries to make a flaky test pass — find why it's flaky.

--- a/.github/prompts/triage-issue.prompt.md
+++ b/.github/prompts/triage-issue.prompt.md
@@ -1,0 +1,13 @@
+---
+mode: agent
+description: Triage a GitHub issue for Substance2Remix — classify, label, hypothesize, ask for the right logs.
+---
+
+Triage the issue I give you (title + body, or a number if GitHub MCP is available): ${input:issue:Issue number, or title + body}
+
+Produce:
+1. **Labels** (≤3) from the repo's label set; prefer specificity (don't apply both `bug` and `question`).
+2. **Exactly one** of: a root-cause hypothesis (only if diagnosable), a specific clarifying question (name the missing field — Painter version? Remix Toolkit version? OS?), or a concrete next step.
+3. For runtime failures, ask for the `Documents/Substance2Remix` logs plus the Painter + Remix Toolkit versions before deep analysis. For "X broke after a Painter update", consider delegating to **painter-api-compat-monitor**; for upstream Remix REST changes, **research-scanner**.
+
+Keep the comment 3–5 sentences. If GitHub MCP is available you may apply labels and post; otherwise output them for me to paste.

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,8 @@ logs/
 Pulled Textures/
 assets/gotoingest/
 settings.json
-.vscode/
+.vscode/*
+!.vscode/mcp.json
 .idea/
 *.log
 *.spec

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,12 @@
+{
+  "servers": {
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/"
+    },
+    "linear": {
+      "type": "http",
+      "url": "https://mcp.linear.app/mcp"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Pilot of a full VSCode **GitHub Copilot Pro+** setup for Substance2Remix — 1 of 2 pilot repos (paired with ACBrotherhoodRTX), bringing this repo up to the standard already used in `TombRaiderLegendRTX-`. **Config only — no plugin behavior changed.**

## What's included

- **Repo-wide instructions** — expanded `.github/copilot-instructions.md` with the module map, the Remix round-trip + TLS invariants (all HTTP via `RemixAPIClient.make_request()`), the `QT_AVAILABLE` guard rule, and the texconv/Blender timeouts.
- **Path-scoped instructions** (`.github/instructions/`, auto-attached via `applyTo`):
  - `python.instructions.md` — Python/Qt rules for `*.py`.
  - `remix-api.instructions.md` — REST-client + texture-pipeline security rules for `remix_api.py` / `texture_processor.py`.
- **Prompt files** (`.github/prompts/`, become `/slash` commands in Copilot Chat): `/add-feature`, `/run-tests`, `/review-pr`, `/triage-issue`.
- **Custom agents** (`.github/agents/`): `research-scanner`, `painter-api-compat-monitor`, `doc-sync`.
- **Agent-mode MCP** (`.vscode/mcp.json`): GitHub + Linear MCP (`https://mcp.linear.app/mcp`, matching the repo's Linear sync). `.gitignore` was narrowed (`.vscode/*` + `!.vscode/mcp.json`) so personal VSCode settings stay ignored but this shared config is tracked.

## Notes

Pilot: once you've reviewed the style here and in ACBrotherhoodRTX, I'll replicate the approved pattern to the other 6 repos.

## Test plan

- [ ] Open the repo in VSCode; confirm Copilot picks up `.github/copilot-instructions.md`.
- [ ] Confirm `/add-feature`, `/run-tests`, `/review-pr`, `/triage-issue` appear as prompts.
- [ ] Open a `.py` file and `remix_api.py`; confirm the correct path-scoped instructions attach.
- [ ] Approve the `.vscode/mcp.json` servers; confirm GitHub + Linear MCP connect (Linear prompts an OAuth sign-in).

https://claude.ai/code/session_017hHCWYgtqCGQwTyuB1rqqr

---
_Generated by [Claude Code](https://claude.ai/code/session_017hHCWYgtqCGQwTyuB1rqqr)_